### PR TITLE
fix(agera): prevent subs count desync when mountable signal is read by non-subscriber node

### DIFF
--- a/packages/agera/.size-limit.json
+++ b/packages/agera/.size-limit.json
@@ -3,13 +3,13 @@
     "name": "All publics",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "2.47 kB"
+    "limit": "2.49 kB"
   },
   {
     "name": "Signal",
     "path": "dist/index.js",
     "import": "{ signal }",
-    "limit": "1.59 kB"
+    "limit": "1.6 kB"
   },
   {
     "name": "Minimal set",
@@ -21,6 +21,6 @@
     "name": "Popular set",
     "path": "dist/index.js",
     "import": "{ signal, computed, effect, mountable, onMounted }",
-    "limit": "1.89 kB"
+    "limit": "1.91 kB"
   }
 ]

--- a/packages/agera/src/internals/lifecycle.ts
+++ b/packages/agera/src/internals/lifecycle.ts
@@ -51,6 +51,12 @@ export function notifyMounted(
 }
 
 /* @__NO_SIDE_EFFECTS__ */
+export function isSubscriber(sub: ReactiveNode | ReadableNode): boolean {
+  // Is it effect or computed?
+  return 'fn' in sub || 'subsCount' in sub
+}
+
+/* @__NO_SIDE_EFFECTS__ */
 export function isActiveSubscriber(sub: ReactiveNode | ReadableNode): boolean {
   // Is it effect or active computed?
   return 'fn' in sub || 'subsCount' in sub && sub.subsCount > 0

--- a/packages/agera/src/internals/system.ts
+++ b/packages/agera/src/internals/system.ts
@@ -30,6 +30,7 @@ import {
 } from './flags.js'
 import {
   incrementEffectCount,
+  isSubscriber,
   isActiveSubscriber,
   decrementEffectCount,
   notifyMounted,
@@ -209,7 +210,7 @@ function unlink(link: Link, sub = link.sub): Link | undefined {
     unwatch = true
   }
 
-  if (isMountableUsed && dep.modes & MountableMode && sub.noMount !== dep) {
+  if (isMountableUsed && dep.modes & MountableMode && isSubscriber(sub) && sub.noMount !== dep) {
     decrementEffectCount(dep, unwatch)
   }
 

--- a/packages/agera/src/modes.spec.ts
+++ b/packages/agera/src/modes.spec.ts
@@ -9,6 +9,7 @@ import {
   signal,
   onMounted,
   effect,
+  trigger,
   mountable,
   isMountable,
   readonly,
@@ -67,6 +68,32 @@ describe('agera', () => {
           'mount',
           'unmount'
         ])
+      })
+
+      it('should not desync subs count when signal is read by non-subscriber node', () => {
+        const $num = mountable(signal(1))
+        const log: string[] = []
+
+        onMounted($num, (mounted) => {
+          log.push(mounted ? 'mount' : 'unmount')
+        })
+
+        const stop = effect(() => {
+          $num()
+        })
+
+        expect($num.node.subsCount).toBe(1)
+        expect(log).toEqual(['mount'])
+
+        trigger($num)
+
+        expect($num.node.subsCount).toBe(1)
+        expect(log).toEqual(['mount'])
+
+        stop()
+
+        expect($num.node.subsCount).toBe(0)
+        expect(log).toEqual(['mount', 'unmount'])
       })
 
       it('should propagate changes from onMounted callback', () => {

--- a/packages/kida/.size-limit.json
+++ b/packages/kida/.size-limit.json
@@ -9,12 +9,12 @@
     "name": "Signal",
     "path": "dist/index.js",
     "import": "{ signal }",
-    "limit": "1.59 kB"
+    "limit": "1.61 kB"
   },
   {
     "name": "Popular set",
     "path": "dist/index.js",
     "import": "{ signal, record, computed, effect, mountable, onMount }",
-    "limit": "2.23 kB"
+    "limit": "2.24 kB"
   }
 ]

--- a/packages/store/.size-limit.json
+++ b/packages/store/.size-limit.json
@@ -9,12 +9,12 @@
     "name": "Signal",
     "path": "dist/index.js",
     "import": "{ signal }",
-    "limit": "1.59 kB"
+    "limit": "1.61 kB"
   },
   {
     "name": "Popular set",
     "path": "dist/index.js",
     "import": "{ signal, record, computed, effect, mountable, onMount }",
-    "limit": "2.23 kB"
+    "limit": "2.25 kB"
   }
 ]


### PR DESCRIPTION
## Problem

`subsCount` accounting for mountable signals is asymmetric in the core:

- `link()` increments `subsCount` only for active subscribers (`isActiveSubscriber`), so temporary nodes — the `trigger()` sub, `effectScope`/`deferScope` nodes — never increment it.
- `unlink()` decremented unconditionally: any unlink of a mountable signal decreased the counter even when there was no matching increment.

As a result `subsCount` desyncs and `mounted(false)` can fire while live subscribers still exist. Reproducible on `main`:

```ts
const $a = mountable(signal(1))
onMounted($a, log)
effect(() => { $a() }) // subsCount = 1, mounted(true)
trigger($a)            // spurious decrement → subsCount = 0, mounted(false) fires
```

## Fix

- New `isSubscriber(sub)` helper in `lifecycle.ts` — shape-based check (`'fn' in sub || 'subsCount' in sub`, i.e. effect or computed). Shape-based rather than state-based on purpose: the transitive computed deactivation flow legitimately decrements when `subsCount` is already 0.
- `unlink()` now guards the decrement with `isSubscriber(sub)`, symmetric to the increment in `link()`.
- Size limits bumped by a few bytes to accommodate the guard.

## Tests

- New regression test in `modes.spec.ts` (fails on `main`).
- agera: 78 passed + 2 expected fail, oxlint and tsc clean; size-limit green.
- kida (the only package depending on agera): 61 passed.