### PR TITLE
feat(ssr): add server entrypoint

### DIFF
--- a/examples/event-board/common/api/index.js
+++ b/examples/event-board/common/api/index.js
@@ -9,7 +9,7 @@ import {
 const HTTP_BAD_REQUEST = 400
 const HTTP_NOT_FOUND = 404
 
-export function createApiApp() {
+export function api() {
   const app = new Hono()
 
   app.get('/api/events', (c) => {
@@ -62,10 +62,4 @@ export function createApiApp() {
   })
 
   return app
-}
-
-export function api() {
-  const app = createApiApp()
-
-  return c => app.fetch(c.req.raw)
 }

--- a/examples/event-board/common/api/server.js
+++ b/examples/event-board/common/api/server.js
@@ -8,7 +8,7 @@ const API_PORT = Number(process.env.PORT || DEFAULT_API_PORT)
 const app = new Hono()
 
 app.use(compress())
-app.use('/api/*', api())
+app.route('/', api())
 
 app.get('/', c => c.redirect('http://localhost:5173'))
 

--- a/examples/event-board/preact-nano_kit-intl-ssr/api/index.js
+++ b/examples/event-board/preact-nano_kit-intl-ssr/api/index.js
@@ -9,7 +9,7 @@ import {
 const HTTP_BAD_REQUEST = 400
 const HTTP_NOT_FOUND = 404
 
-export function createApiApp() {
+export function api() {
   const app = new Hono()
 
   app.get('/api/events', (c) => {
@@ -62,10 +62,4 @@ export function createApiApp() {
   })
 
   return app
-}
-
-export function api() {
-  const app = createApiApp()
-
-  return c => app.fetch(c.req.raw)
 }

--- a/examples/event-board/preact-nano_kit-intl-ssr/api/server.js
+++ b/examples/event-board/preact-nano_kit-intl-ssr/api/server.js
@@ -8,7 +8,7 @@ const API_PORT = Number(process.env.PORT || DEFAULT_API_PORT)
 const app = new Hono()
 
 app.use(compress())
-app.use('/api/*', api())
+app.route('/', api())
 
 app.get('/', c => c.redirect('http://localhost:5173'))
 

--- a/examples/event-board/preact-nano_kit-intl-ssr/package.json
+++ b/examples/event-board/preact-nano_kit-intl-ssr/package.json
@@ -11,8 +11,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "build:only": "vite build",
-    "preview": "node server.js",
-    "start": "node server.js"
+    "preview": "node dist/server/index.js",
+    "start": "node dist/server/index.js"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.9",

--- a/examples/event-board/preact-nano_kit-intl-ssr/src/server.ts
+++ b/examples/event-board/preact-nano_kit-intl-ssr/src/server.ts
@@ -1,9 +1,10 @@
+import type { RedirectStatusCode } from 'hono/utils/http-status'
 import { serve } from '@hono/node-server'
 import { serveStatic } from '@hono/node-server/serve-static'
 import { Hono } from 'hono'
 import { compress } from 'hono/compress'
-import { renderer } from './dist/renderer/index.js'
-import { api } from './api/index.js'
+import { renderer } from 'virtual:app-renderer'
+import { api } from '../api/index.js'
 
 const DEFAULT_PORT = 3001
 const CACHE_MAX_AGE = 31_536_000
@@ -11,7 +12,7 @@ const PORT = Number(process.env.PORT || DEFAULT_PORT)
 const app = new Hono()
 
 app.use(compress())
-app.use('/api/*', api())
+app.route('/', api())
 
 app.use(`${renderer.base.replace(/(.)\/$/, '$1')}*`, serveStatic({
   root: './dist/client',
@@ -21,10 +22,13 @@ app.use(`${renderer.base.replace(/(.)\/$/, '$1')}*`, serveStatic({
 }))
 
 app.get('*', async (c) => {
-  const result = await renderer.render(c.req.url)
+  const result = await renderer.render(c.req.url, {
+    cookie: c.req.header('Cookie'),
+    acceptLanguage: c.req.header('Accept-Language')
+  })
 
   if (result.redirect) {
-    return c.redirect(result.redirect, result.statusCode)
+    return c.redirect(result.redirect, result.statusCode as RedirectStatusCode)
   }
 
   if (result.html !== null) {

--- a/examples/event-board/preact-nano_kit-intl-ssr/vite.config.ts
+++ b/examples/event-board/preact-nano_kit-intl-ssr/vite.config.ts
@@ -2,17 +2,20 @@ import { defineConfig } from 'vite'
 import preact from '@preact/preset-vite'
 import ssr from '@nano_kit/preact-ssr/vite-plugin'
 import { getRequestListener } from '@hono/node-server'
-import { createApiApp } from './api/index.js'
+import { api } from './api/index.js'
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   build: {
     target: 'esnext'
+  },
+  ssr: {
+    noExternal: command === 'build' || undefined
   },
   plugins: [
     {
       name: 'event-board-api',
       configureServer(server) {
-        const listener = getRequestListener(createApiApp().fetch)
+        const listener = getRequestListener(api().fetch)
 
         server.middlewares.use((req, res, next) => {
           if (!req.url?.startsWith('/api')) {
@@ -28,10 +31,11 @@ export default defineConfig({
     preact(),
     ssr({
       index: 'src/index.tsx',
+      server: 'src/server.ts',
       inject: {
         cookieStore: true,
         browserLocale: true
       }
     })
   ]
-})
+}))

--- a/examples/event-board/react-nano_kit-intl-ssr/api/index.js
+++ b/examples/event-board/react-nano_kit-intl-ssr/api/index.js
@@ -9,7 +9,7 @@ import {
 const HTTP_BAD_REQUEST = 400
 const HTTP_NOT_FOUND = 404
 
-export function createApiApp() {
+export function api() {
   const app = new Hono()
 
   app.get('/api/events', (c) => {
@@ -62,10 +62,4 @@ export function createApiApp() {
   })
 
   return app
-}
-
-export function api() {
-  const app = createApiApp()
-
-  return c => app.fetch(c.req.raw)
 }

--- a/examples/event-board/react-nano_kit-intl-ssr/api/server.js
+++ b/examples/event-board/react-nano_kit-intl-ssr/api/server.js
@@ -8,7 +8,7 @@ const API_PORT = Number(process.env.PORT || DEFAULT_API_PORT)
 const app = new Hono()
 
 app.use(compress())
-app.use('/api/*', api())
+app.route('/', api())
 
 app.get('/', c => c.redirect('http://localhost:5173'))
 

--- a/examples/event-board/react-nano_kit-intl-ssr/package.json
+++ b/examples/event-board/react-nano_kit-intl-ssr/package.json
@@ -11,8 +11,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "build:only": "vite build",
-    "preview": "node server.js",
-    "start": "node server.js"
+    "preview": "node dist/server/index.js",
+    "start": "node dist/server/index.js"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.9",

--- a/examples/event-board/react-nano_kit-intl-ssr/src/server.ts
+++ b/examples/event-board/react-nano_kit-intl-ssr/src/server.ts
@@ -1,9 +1,10 @@
+import type { RedirectStatusCode } from 'hono/utils/http-status'
 import { serve } from '@hono/node-server'
 import { serveStatic } from '@hono/node-server/serve-static'
 import { Hono } from 'hono'
 import { compress } from 'hono/compress'
-import { renderer } from './dist/renderer/index.js'
-import { api } from './api/index.js'
+import { renderer } from 'virtual:app-renderer'
+import { api } from '../api/index.js'
 
 const DEFAULT_PORT = 3001
 const CACHE_MAX_AGE = 31_536_000
@@ -11,7 +12,7 @@ const PORT = Number(process.env.PORT || DEFAULT_PORT)
 const app = new Hono()
 
 app.use(compress())
-app.use('/api/*', api())
+app.route('/', api())
 
 app.use(`${renderer.base.replace(/(.)\/$/, '$1')}*`, serveStatic({
   root: './dist/client',
@@ -27,7 +28,7 @@ app.get('*', async (c) => {
   })
 
   if (result.redirect) {
-    return c.redirect(result.redirect, result.statusCode)
+    return c.redirect(result.redirect, result.statusCode as RedirectStatusCode)
   }
 
   if (result.html !== null) {

--- a/examples/event-board/react-nano_kit-intl-ssr/vite.config.ts
+++ b/examples/event-board/react-nano_kit-intl-ssr/vite.config.ts
@@ -2,17 +2,20 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import ssr from '@nano_kit/react-ssr/vite-plugin'
 import { getRequestListener } from '@hono/node-server'
-import { createApiApp } from './api/index.js'
+import { api } from './api/index.js'
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   build: {
     target: 'esnext'
+  },
+  ssr: {
+    noExternal: command === 'build' || undefined
   },
   plugins: [
     {
       name: 'event-board-api',
       configureServer(server) {
-        const listener = getRequestListener(createApiApp().fetch)
+        const listener = getRequestListener(api().fetch)
 
         server.middlewares.use((req, res, next) => {
           if (!req.url?.startsWith('/api')) {
@@ -28,10 +31,11 @@ export default defineConfig({
     react(),
     ssr({
       index: 'src/index.tsx',
+      server: 'src/server.ts',
       inject: {
         cookieStore: true,
         browserLocale: true
       }
     })
   ]
-})
+}))

--- a/examples/event-board/svelte-nano_kit-ssr/api/index.js
+++ b/examples/event-board/svelte-nano_kit-ssr/api/index.js
@@ -9,7 +9,7 @@ import {
 const HTTP_BAD_REQUEST = 400
 const HTTP_NOT_FOUND = 404
 
-export function createApiApp() {
+export function api() {
   const app = new Hono()
 
   app.get('/api/events', (c) => {
@@ -62,10 +62,4 @@ export function createApiApp() {
   })
 
   return app
-}
-
-export function api() {
-  const app = createApiApp()
-
-  return c => app.fetch(c.req.raw)
 }

--- a/examples/event-board/svelte-nano_kit-ssr/api/server.js
+++ b/examples/event-board/svelte-nano_kit-ssr/api/server.js
@@ -8,7 +8,7 @@ const API_PORT = Number(process.env.PORT || DEFAULT_API_PORT)
 const app = new Hono()
 
 app.use(compress())
-app.use('/api/*', api())
+app.route('/', api())
 
 app.get('/', c => c.redirect('http://localhost:5173'))
 

--- a/examples/event-board/svelte-nano_kit-ssr/package.json
+++ b/examples/event-board/svelte-nano_kit-ssr/package.json
@@ -11,8 +11,8 @@
     "dev": "vite",
     "build": "svelte-check --tsconfig ./tsconfig.json && tsc --noEmit -p tsconfig.node.json && vite build",
     "build:only": "vite build",
-    "preview": "node server.js",
-    "start": "node server.js",
+    "preview": "node dist/server/index.js",
+    "start": "node dist/server/index.js",
     "test:types": "svelte-check --tsconfig ./tsconfig.json && tsc --noEmit -p tsconfig.node.json"
   },
   "dependencies": {

--- a/examples/event-board/svelte-nano_kit-ssr/src/server.ts
+++ b/examples/event-board/svelte-nano_kit-ssr/src/server.ts
@@ -1,9 +1,10 @@
+import type { RedirectStatusCode } from 'hono/utils/http-status'
 import { serve } from '@hono/node-server'
 import { serveStatic } from '@hono/node-server/serve-static'
 import { Hono } from 'hono'
 import { compress } from 'hono/compress'
-import { renderer } from './dist/renderer/index.js'
-import { api } from './api/index.js'
+import { renderer } from 'virtual:app-renderer'
+import { api } from '../api/index.js'
 
 const DEFAULT_PORT = 3001
 const CACHE_MAX_AGE = 31_536_000
@@ -11,7 +12,7 @@ const PORT = Number(process.env.PORT || DEFAULT_PORT)
 const app = new Hono()
 
 app.use(compress())
-app.use('/api/*', api())
+app.route('/', api())
 
 app.use(`${renderer.base.replace(/(.)\/$/, '$1')}*`, serveStatic({
   root: './dist/client',
@@ -21,13 +22,10 @@ app.use(`${renderer.base.replace(/(.)\/$/, '$1')}*`, serveStatic({
 }))
 
 app.get('*', async (c) => {
-  const result = await renderer.render(c.req.url, {
-    cookie: c.req.header('Cookie'),
-    acceptLanguage: c.req.header('Accept-Language')
-  })
+  const result = await renderer.render(c.req.url)
 
   if (result.redirect) {
-    return c.redirect(result.redirect, result.statusCode)
+    return c.redirect(result.redirect, result.statusCode as RedirectStatusCode)
   }
 
   if (result.html !== null) {

--- a/examples/event-board/svelte-nano_kit-ssr/vite.config.ts
+++ b/examples/event-board/svelte-nano_kit-ssr/vite.config.ts
@@ -2,17 +2,20 @@ import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import ssr from '@nano_kit/svelte-ssr/vite-plugin'
 import { getRequestListener } from '@hono/node-server'
-import { createApiApp } from './api/index.js'
+import { api } from './api/index.js'
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   build: {
     target: 'esnext'
+  },
+  ssr: {
+    noExternal: command === 'build' || undefined
   },
   plugins: [
     {
       name: 'event-board-api',
       configureServer(server) {
-        const listener = getRequestListener(createApiApp().fetch)
+        const listener = getRequestListener(api().fetch)
 
         server.middlewares.use((req, res, next) => {
           if (!req.url?.startsWith('/api')) {
@@ -27,7 +30,8 @@ export default defineConfig({
     },
     svelte(),
     ssr({
-      index: 'src/index.ts'
+      index: 'src/index.ts',
+      server: 'src/server.ts'
     })
   ]
-})
+}))

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -61,7 +61,7 @@
     "clear": "del ./package ./dist ./coverage",
     "prepublishOnly": "run build clear:package clean-publish",
     "postpublish": "pnpm clear:package",
-    "build:dist": "tsc -p tsconfig.build.json; cpy ./src/vite-plugin/index.d.ts ./dist/vite-plugin --flat",
+    "build:dist": "tsc -p tsconfig.build.json; cpy './src/vite-plugin/*.d.ts' ./dist/vite-plugin --flat",
     "build": "run clear:dist build:dist",
     "lint": "oxlint",
     "format": "oxlint --fix",

--- a/packages/ssr/src/renderer/renderer.types.ts
+++ b/packages/ssr/src/renderer/renderer.types.ts
@@ -7,6 +7,21 @@ import type {
   UnknownMatchRef
 } from '@nano_kit/router'
 import type { ManifestOptions } from './manifest.types.js'
+import type {
+  SUCCESS_STATUS,
+  MOVED_PERMANENTLY_STATUS,
+  FOUND_STATUS,
+  NOT_FOUND_STATUS
+} from './constants.js'
+
+/**
+ * Response status codes that the renderer can produce.
+ */
+export type ResponseStatusCode =
+  | typeof SUCCESS_STATUS
+  | typeof MOVED_PERMANENTLY_STATUS
+  | typeof FOUND_STATUS
+  | typeof NOT_FOUND_STATUS
 
 export interface KnownHeaders {
   cookie?: string
@@ -48,7 +63,7 @@ export interface RenderData {
   context: InjectionContext
   head: HeadDescriptor[]
   dehydrated: [string, unknown][]
-  statusCode: number
+  statusCode: ResponseStatusCode
   redirect: string | null
   page: PageRef<unknown> | null
   setCookieHeaders: string[] | null

--- a/packages/ssr/src/renderer/utils.ts
+++ b/packages/ssr/src/renderer/utils.ts
@@ -9,6 +9,7 @@ import {
   get,
   isEmpty
 } from '@nano_kit/store'
+import type { ResponseStatusCode } from './renderer.types.js'
 import {
   FOUND_STATUS,
   MOVED_PERMANENTLY_STATUS,
@@ -48,7 +49,7 @@ export function headDescriptorToHtml(descriptor: HeadDescriptor): string {
 
 export function responseRedirect(
   location: Location
-): [number, string] | null {
+): [typeof MOVED_PERMANENTLY_STATUS | typeof FOUND_STATUS, string] | null {
   const { action } = location
 
   if (action) {
@@ -65,7 +66,7 @@ export function responseRedirect(
 export function responseStatus(
   location: Location,
   page: PageRef<unknown> | null
-): [number, string | null] {
+): [ResponseStatusCode, string | null] {
   const redirect = responseRedirect(location)
 
   if (redirect) {
@@ -74,7 +75,7 @@ export function responseStatus(
 
   return [
     page
-      ? page.statusCode ?? SUCCESS_STATUS
+      ? (page.statusCode as ResponseStatusCode) ?? SUCCESS_STATUS
       : NOT_FOUND_STATUS,
     null
   ]

--- a/packages/ssr/src/vite-plugin/index.d.ts
+++ b/packages/ssr/src/vite-plugin/index.d.ts
@@ -1,3 +1,4 @@
+import './virtual.js'
 import type { Plugin } from 'vite'
 
 export interface SsrPluginAdapter {
@@ -37,6 +38,18 @@ export interface BaseSsrPluginOptions {
    * @default 'renderer'
    */
   rendererDir?: string
+  /**
+   * Path to the server entry file. When set, this file is bundled instead of the
+   * renderer (into `serverDir`), and the renderer is exposed to it through the
+   * `virtual:app-renderer` module.
+   */
+  server?: string
+  /**
+   * Directory inside the build output for server assets. Used only when the
+   * `server` option is set.
+   * @default 'server'
+   */
+  serverDir?: string
   /**
    * Development options.
    */

--- a/packages/ssr/src/vite-plugin/index.js
+++ b/packages/ssr/src/vite-plugin/index.js
@@ -21,8 +21,10 @@ export default function SsrPlugin(options, adapter) {
     index: appIndex,
     client: clientPath = adapter.clientPath,
     renderer: rendererPath = adapter.rendererPath,
+    server: serverPath,
     clientDir = 'client',
     rendererDir = 'renderer',
+    serverDir = 'server',
     nativeMagicString = true,
     inject = {},
     dev = {}
@@ -108,6 +110,16 @@ export default function SsrPlugin(options, adapter) {
           return this.resolve(appIndex, importer, {
             ...options,
             isEntry: true
+          })
+        }
+
+        if (id === 'virtual:app-renderer') {
+          // `skipSelf: false` lets the adapter's default renderer (a virtual id
+          // that only this plugin's `resolveId` below knows how to handle) resolve;
+          // otherwise `this.resolve` would skip this plugin and return `null`.
+          return this.resolve(rendererPath, importer, {
+            ...options,
+            skipSelf: false
           })
         }
 
@@ -222,6 +234,7 @@ export default function SsrPlugin(options, adapter) {
         const outDir = config.build?.outDir || 'dist'
         const outClientDir = path.join(outDir, clientDir)
         const outRendererDir = path.join(outDir, rendererDir)
+        const outServerDir = serverPath && path.join(outDir, serverDir)
         const manifestOption = config.build?.manifest || true
         const manifestPath = typeof manifestOption === 'string'
           ? path.join(outClientDir, manifestOption)
@@ -233,7 +246,7 @@ export default function SsrPlugin(options, adapter) {
 
         if (isSsrBuild) {
           const bundlerOptions = {
-            input: rendererPath,
+            input: serverPath ?? rendererPath,
             output: {
               entryFileNames: 'index.js'
             }
@@ -245,7 +258,7 @@ export default function SsrPlugin(options, adapter) {
               sourcemap: true,
               rollupOptions: bundlerOptions,
               rolldownOptions: bundlerOptions,
-              outDir: outRendererDir
+              outDir: outServerDir || outRendererDir
             }
           }
         }

--- a/packages/ssr/src/vite-plugin/index.spec.ts
+++ b/packages/ssr/src/vite-plugin/index.spec.ts
@@ -187,5 +187,34 @@ describe('ssr', () => {
       expect(rendererPageChunk.code).toContain('"Home Page"')
       expect(rendererPageChunk.code).toContain('Stores$')
     })
+
+    it('should build the server entry with virtual:app-renderer when server option is set', async () => {
+      const plugin = SsrPlugin({
+        index: input,
+        server: path.join(testAppDir, 'server.js')
+      }, adapter)
+      const serverResult: any = await build({
+        root: testAppDir,
+        logLevel: 'silent',
+        plugins: plugin,
+        build: {
+          minify: false,
+          ssr: true
+        }
+      })
+      const serverChunk = serverResult.output.find((c: any) => c.facadeModuleId?.endsWith('server.js'))
+
+      expect(serverChunk).toBeDefined()
+      expect(serverChunk.fileName).toBe('index.js')
+      expect(serverChunk.code).toContain('console.log("Server:"')
+      expect(serverChunk.code).toContain('console.log("Virtual renderer:"')
+      expect(serverChunk.code).toContain('__attachChunkname')
+
+      const serverPageChunk = serverResult.output.find((c: any) => c.facadeModuleId?.endsWith('home.js'))
+
+      expect(serverPageChunk).toBeDefined()
+      expect(serverPageChunk.code).toContain('"Home Page"')
+      expect(serverPageChunk.code).toContain('Stores$')
+    })
   })
 })

--- a/packages/ssr/src/vite-plugin/virtual.d.ts
+++ b/packages/ssr/src/vite-plugin/virtual.d.ts
@@ -1,0 +1,11 @@
+// This file must stay a script (no top-level import/export), otherwise the
+// ambient module declaration below stops being registered globally.
+
+declare module 'virtual:app-renderer' {
+  /**
+   * The SSR renderer instance, provided by the configured renderer entry.
+   * Available to the `server` entry when the `server` plugin option is set.
+   */
+  // oxlint-disable-next-line typescript/consistent-type-imports
+  export const renderer: import('../renderer/index.js').Renderer
+}

--- a/packages/ssr/test/app/server.js
+++ b/packages/ssr/test/app/server.js
@@ -1,0 +1,7 @@
+import { renderer } from 'virtual:app-renderer'
+
+if (!import.meta.env.VITEST) {
+  console.log('Server:', renderer)
+}
+
+export { renderer }


### PR DESCRIPTION
## Summary

Adds an optional `server` entrypoint to `@nano_kit/ssr`, alongside the existing `client` and `renderer`.

When the `server` plugin option is set, that file is bundled into `dist/server` (instead of emitting the default renderer bundle) and receives the renderer through a new typed `virtual:app-renderer` module. Default behaviour is unchanged — without `server`, the renderer bundle is still produced.

## Changes

- **`@nano_kit/ssr` vite-plugin**: `server` / `serverDir` options, `virtual:app-renderer` resolution, and an SSR build branch that emits the server bundle.
- **Types**: ambient `virtual:app-renderer` declaration (shipped script `virtual.d.ts` pulled in from `index.d.ts`); `RenderData.statusCode` narrowed to a `ResponseStatusCode` literal union.
- **Examples**: event-board react/preact/svelte moved to `src/server.ts` importing `virtual:app-renderer`; server build bundles deps via `ssr.noExternal` (gated to `build`, so dev still loads the renderer through Vite's SSR module runner); api factory renamed to `api`.

## Testing

- `packages/ssr`: oxlint + vitest (incl. new server-build test) + tsc — green.
- Examples: build emits `dist/server` + `dist/client`; prod server (SSR + bundled api + static with cache headers) and dev (SSR middleware + api plugin) verified at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
