### PR TITLE
fix(router): preserve `statusCode` of loadable `notFound` pages

### DIFF
--- a/packages/router/src/router.spec.ts
+++ b/packages/router/src/router.spec.ts
@@ -107,6 +107,28 @@ describe('router', () => {
       expect($page()?.default).toBe('Not Found Page')
     })
 
+    it('should keep status code for loadable not found page', async () => {
+      const [$location, navigation] = virtualNavigation('/', {
+        home: '/home'
+      })
+      const notFoundPagePromise = Promise.resolve({
+        default: 'Not Found Page'
+      })
+      const $page = router($location, [
+        page('home', 'Home Page'),
+        notFound(loadable(() => notFoundPagePromise))
+      ])
+
+      navigation.push('/unknown')
+
+      expect($page()?.statusCode).toBe(404)
+
+      await notFoundPagePromise
+
+      expect($page()?.default).toBe('Not Found Page')
+      expect($page()?.statusCode).toBe(404)
+    })
+
     it('should expose page stores when provided', () => {
       const [$location, navigation] = virtualNavigation('/', {
         home: '/home',

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -82,7 +82,12 @@ function getViewRefGetter<C>(
   let getter: PageRefGetter<C>
 
   if (isLoadable(page)) {
-    getter = page.load
+    getter = extra
+      ? tasks => ({
+        ...extra,
+        ...page.load(tasks)
+      })
+      : page.load
   } else {
     const ref = isModule(page)
       ? {


### PR DESCRIPTION
`getViewRefGetter` returned the loadable ref loader directly and dropped the extra page module fields, so `notFound(loadable(...))` rendered with status 200 instead of 404.

- sync wrapper merges the extra module fields over the loaded ref
- unit test: `notFound(loadable(...))` keeps `statusCode: 404` before and after the module loads