### PR TITLE
chore: gate size limits on gzip and brotli

### DIFF
--- a/packages/agera/.size-limit.json
+++ b/packages/agera/.size-limit.json
@@ -1,26 +1,54 @@
 [
   {
-    "name": "All publics",
+    "name": "All publics (Gzip)",
+    "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "2.73 kB"
+    "limit": "2.95 kB"
   },
   {
-    "name": "Signal",
+    "name": "All publics (Brotli)",
+    "path": "dist/index.js",
+    "import": "*",
+    "limit": "2.75 kB"
+  },
+  {
+    "name": "Signal (Gzip)",
+    "gzip": true,
+    "path": "dist/index.js",
+    "import": "{ signal }",
+    "limit": "1.45 kB"
+  },
+  {
+    "name": "Signal (Brotli)",
     "path": "dist/index.js",
     "import": "{ signal }",
     "limit": "1.35 kB"
   },
   {
-    "name": "Minimal set",
+    "name": "Minimal set (Gzip)",
+    "gzip": true,
     "path": "dist/index.js",
     "import": "{ signal, computed, effect }",
-    "limit": "1.52 kB"
+    "limit": "1.65 kB"
   },
   {
-    "name": "Popular set",
+    "name": "Minimal set (Brotli)",
+    "path": "dist/index.js",
+    "import": "{ signal, computed, effect }",
+    "limit": "1.55 kB"
+  },
+  {
+    "name": "Popular set (Gzip)",
+    "gzip": true,
     "path": "dist/index.js",
     "import": "{ signal, computed, effect, mountable, onMounted }",
-    "limit": "1.93 kB"
+    "limit": "2.1 kB"
+  },
+  {
+    "name": "Popular set (Brotli)",
+    "path": "dist/index.js",
+    "import": "{ signal, computed, effect, mountable, onMounted }",
+    "limit": "1.95 kB"
   }
 ]

--- a/packages/intl/.size-limit.json
+++ b/packages/intl/.size-limit.json
@@ -1,18 +1,39 @@
 [
   {
-    "name": "All publics",
+    "name": "All publics (Gzip)",
+    "gzip": true,
+    "path": "dist/index.js",
+    "import": "*",
+    "limit": "2 kB"
+  },
+  {
+    "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
     "limit": "1.85 kB"
   },
   {
-    "name": "Minimal set",
+    "name": "Minimal set (Gzip)",
+    "gzip": true,
     "path": "dist/index.js",
     "import": "{ intl, text, params }",
-    "limit": "490 B"
+    "limit": "600 B"
   },
   {
-    "name": "Basic set",
+    "name": "Minimal set (Brotli)",
+    "path": "dist/index.js",
+    "import": "{ intl, text, params }",
+    "limit": "500 B"
+  },
+  {
+    "name": "Basic set (Gzip)",
+    "gzip": true,
+    "path": "dist/index.js",
+    "import": "{ intl, text, number, datetime, params, plural, match, cases }",
+    "limit": "1 kB"
+  },
+  {
+    "name": "Basic set (Brotli)",
     "path": "dist/index.js",
     "import": "{ intl, text, number, datetime, params, plural, match, cases }",
     "limit": "900 B"

--- a/packages/kida/.size-limit.json
+++ b/packages/kida/.size-limit.json
@@ -1,20 +1,41 @@
 [
   {
-    "name": "All publics",
+    "name": "All publics (Gzip)",
+    "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "4.19 kB"
+    "limit": "4.55 kB"
   },
   {
-    "name": "Signal",
+    "name": "All publics (Brotli)",
+    "path": "dist/index.js",
+    "import": "*",
+    "limit": "4.2 kB"
+  },
+  {
+    "name": "Signal (Gzip)",
+    "gzip": true,
+    "path": "dist/index.js",
+    "import": "{ signal }",
+    "limit": "1.45 kB"
+  },
+  {
+    "name": "Signal (Brotli)",
     "path": "dist/index.js",
     "import": "{ signal }",
     "limit": "1.35 kB"
   },
   {
-    "name": "Popular set",
+    "name": "Popular set (Gzip)",
+    "gzip": true,
     "path": "dist/index.js",
     "import": "{ signal, record, computed, effect, mountable, onMount }",
-    "limit": "2.28 kB"
+    "limit": "2.45 kB"
+  },
+  {
+    "name": "Popular set (Brotli)",
+    "path": "dist/index.js",
+    "import": "{ signal, record, computed, effect, mountable, onMount }",
+    "limit": "2.3 kB"
   }
 ]

--- a/packages/nanoviews/.size-limit.json
+++ b/packages/nanoviews/.size-limit.json
@@ -1,12 +1,26 @@
 [
   {
-    "name": "All publics",
+    "name": "All publics (Gzip)",
+    "gzip": true,
+    "path": "dist/index.js",
+    "import": "*",
+    "limit": "7.7 kB"
+  },
+  {
+    "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
     "limit": "6.85 kB"
   },
   {
-    "name": "Average usage",
+    "name": "Average usage (Gzip)",
+    "gzip": true,
+    "path": "dist/index.js",
+    "import": "{ fragment, div, form, input, button, label, classList$, if_, for_, value$, $$children, effect }",
+    "limit": "4.45 kB"
+  },
+  {
+    "name": "Average usage (Brotli)",
     "path": "dist/index.js",
     "import": "{ fragment, div, form, input, button, label, classList$, if_, for_, value$, $$children, effect }",
     "limit": "4.05 kB"

--- a/packages/next-router/.size-limit.json
+++ b/packages/next-router/.size-limit.json
@@ -1,8 +1,15 @@
 [
   {
-    "name": "All publics",
+    "name": "All publics (Gzip)",
+    "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "2.7 kB"
+    "limit": "2.9 kB"
+  },
+  {
+    "name": "All publics (Brotli)",
+    "path": "dist/index.js",
+    "import": "*",
+    "limit": "2.65 kB"
   }
 ]

--- a/packages/platform-web/.size-limit.json
+++ b/packages/platform-web/.size-limit.json
@@ -1,8 +1,15 @@
 [
   {
-    "name": "All publics",
+    "name": "All publics (Gzip)",
+    "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "3.04 kB"
+    "limit": "3.4 kB"
+  },
+  {
+    "name": "All publics (Brotli)",
+    "path": "dist/index.js",
+    "import": "*",
+    "limit": "3.05 kB"
   }
 ]

--- a/packages/preact-router/.size-limit.json
+++ b/packages/preact-router/.size-limit.json
@@ -1,6 +1,13 @@
 [
   {
-    "name": "All publics",
+    "name": "All publics (Gzip)",
+    "gzip": true,
+    "path": "dist/index.js",
+    "import": "*",
+    "limit": "1.5 kB"
+  },
+  {
+    "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
     "limit": "1.35 kB"

--- a/packages/preact/.size-limit.json
+++ b/packages/preact/.size-limit.json
@@ -1,8 +1,15 @@
 [
   {
-    "name": "All publics",
+    "name": "All publics (Gzip)",
+    "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "1 kB"
+    "limit": "700 B"
+  },
+  {
+    "name": "All publics (Brotli)",
+    "path": "dist/index.js",
+    "import": "*",
+    "limit": "600 B"
   }
 ]

--- a/packages/query/.size-limit.json
+++ b/packages/query/.size-limit.json
@@ -1,14 +1,28 @@
 [
   {
-    "name": "All publics",
+    "name": "All publics (Gzip)",
+    "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "4.26 kB"
+    "limit": "4.7 kB"
   },
   {
-    "name": "Minimal set",
+    "name": "All publics (Brotli)",
+    "path": "dist/index.js",
+    "import": "*",
+    "limit": "4.3 kB"
+  },
+  {
+    "name": "Minimal set (Gzip)",
+    "gzip": true,
     "path": "dist/index.js",
     "import": "{ client, mutations, queryKey }",
-    "limit": "1.71 kB"
+    "limit": "1.9 kB"
+  },
+  {
+    "name": "Minimal set (Brotli)",
+    "path": "dist/index.js",
+    "import": "{ client, mutations, queryKey }",
+    "limit": "1.7 kB"
   }
 ]

--- a/packages/react-router/.size-limit.json
+++ b/packages/react-router/.size-limit.json
@@ -1,6 +1,13 @@
 [
   {
-    "name": "All publics",
+    "name": "All publics (Gzip)",
+    "gzip": true,
+    "path": "dist/index.js",
+    "import": "*",
+    "limit": "1.45 kB"
+  },
+  {
+    "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
     "limit": "1.35 kB"

--- a/packages/react/.size-limit.json
+++ b/packages/react/.size-limit.json
@@ -1,8 +1,15 @@
 [
   {
-    "name": "All publics",
+    "name": "All publics (Gzip)",
+    "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "1 kB"
+    "limit": "1.05 kB"
+  },
+  {
+    "name": "All publics (Brotli)",
+    "path": "dist/index.js",
+    "import": "*",
+    "limit": "950 B"
   }
 ]

--- a/packages/router/.size-limit.json
+++ b/packages/router/.size-limit.json
@@ -1,12 +1,26 @@
 [
   {
-    "name": "All publics",
+    "name": "All publics (Gzip)",
+    "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "3.74 kB"
+    "limit": "4.15 kB"
   },
   {
-    "name": "Minimal set",
+    "name": "All publics (Brotli)",
+    "path": "dist/index.js",
+    "import": "*",
+    "limit": "3.75 kB"
+  },
+  {
+    "name": "Minimal set (Gzip)",
+    "gzip": true,
+    "path": "dist/index.js",
+    "import": "{ browserNavigation, listenLinks, router, buildPaths }",
+    "limit": "1.55 kB"
+  },
+  {
+    "name": "Minimal set (Brotli)",
     "path": "dist/index.js",
     "import": "{ browserNavigation, listenLinks, router, buildPaths }",
     "limit": "1.4 kB"

--- a/packages/store/.size-limit.json
+++ b/packages/store/.size-limit.json
@@ -1,20 +1,41 @@
 [
   {
-    "name": "All publics",
+    "name": "All publics (Gzip)",
+    "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "5.61 kB"
+    "limit": "6.1 kB"
   },
   {
-    "name": "Signal",
+    "name": "All publics (Brotli)",
+    "path": "dist/index.js",
+    "import": "*",
+    "limit": "5.65 kB"
+  },
+  {
+    "name": "Signal (Gzip)",
+    "gzip": true,
+    "path": "dist/index.js",
+    "import": "{ signal }",
+    "limit": "1.45 kB"
+  },
+  {
+    "name": "Signal (Brotli)",
     "path": "dist/index.js",
     "import": "{ signal }",
     "limit": "1.35 kB"
   },
   {
-    "name": "Popular set",
+    "name": "Popular set (Gzip)",
+    "gzip": true,
     "path": "dist/index.js",
     "import": "{ signal, record, computed, effect, mountable, onMount }",
-    "limit": "2.28 kB"
+    "limit": "2.45 kB"
+  },
+  {
+    "name": "Popular set (Brotli)",
+    "path": "dist/index.js",
+    "import": "{ signal, record, computed, effect, mountable, onMount }",
+    "limit": "2.3 kB"
   }
 ]

--- a/packages/svelte/.size-limit.json
+++ b/packages/svelte/.size-limit.json
@@ -1,8 +1,15 @@
 [
   {
-    "name": "All publics",
+    "name": "All publics (Gzip)",
+    "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "1 kB"
+    "limit": "350 B"
+  },
+  {
+    "name": "All publics (Brotli)",
+    "path": "dist/index.js",
+    "import": "*",
+    "limit": "250 B"
   }
 ]


### PR DESCRIPTION
Every size-limit entry is now measured twice — `(Gzip)` and `(Brotli)` — and every limit is the measured size rounded up to the nearest 50 B. No runtime code changes.

## Why

We had been making design decisions on single- and double-digit brotli deltas. Those deltas turned out to be largely not real.

**Noise.** I took the built `dist/index.js` and produced 10 semantically neutral perturbations by swapping pairs of top-level `function` declarations. Raw minified output stayed **byte-identical across all 11 builds** (19323 B for nanoviews `All publics`), so every movement below is pure compression response to identifier reshuffling by the minifier:

| metric | spread over 11 neutral builds |
|---|---|
| gzip, All publics | **10 B** (0.13%) |
| brotli q11, All publics | **47 B** (0.69%) |
| gzip, Average usage | **6 B** (0.14%) |
| brotli q11, Average usage | **40 B** (1.0%) |

**How each metric prices duplication.** Appending 1, 2 and 4 extra copies of a 292 B minified function:

| variant | raw | gzip | brotli q11 |
|---|---|---|---|
| baseline | 19323 | 7638 | 6822 |
| +1 copy | +292 | +25 | **−25** |
| +2 copies | +584 | +39 | +5 |
| +4 copies | +1168 | +64 | +28 |

Raw charges 100% per copy, which would push us to extract helpers that are not worth extracting. Brotli q11 charges ~0% and is not even monotonic — 1168 B of duplicated code lands inside its own noise band. Gzip charges ~8.5% for the first copy and ~4% for each additional one: it keeps the compression discount that makes a compressed metric worth having, while still producing a monotonic, measurable signal.

Two more findings worth recording:

- The instability is specific to **q11**. Under the same perturbations, brotli **q5** — what dynamic CDN/nginx compression actually emits — has a spread of 12 B and prices duplication like gzip (+27 for the first copy). The "duplication is free" behaviour is an artifact of the q11 optimizer, not of brotli.
- Isolated numbers overstate the real cost. Measured as `compressed(app + lib) − compressed(app)` against real minified app bundles, nanoviews `All publics` costs 6100–6600 B rather than the ~6800 B it reports in a vacuum, and the *isolated gzip delta* predicts the in-app marginal gzip delta to within 1–2 B. Brotli q11 has no such property: for byte-identical variants the in-app marginal delta has a standard deviation of 80–120 B.

## How to read the two numbers

- **Gzip** is the one to compare implementations by. Nearly deterministic, composable, still rewards repetition.
- **Brotli** stays because it is what users are served, and it is the number worth quoting.

Limits are pinned to a clean build of this branch, so they reflect current `main` exactly.
