### PR TITLE
fix(nanoviews): apply multi-word and custom style properties

### DIFF
--- a/packages/nanoviews/.size-limit.json
+++ b/packages/nanoviews/.size-limit.json
@@ -4,13 +4,13 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "7.7 kB"
+    "limit": "7.75 kB"
   },
   {
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "6.85 kB"
+    "limit": "6.9 kB"
   },
   {
     "name": "Average usage (Gzip)",

--- a/packages/nanoviews/src/elements/style.spec.ts
+++ b/packages/nanoviews/src/elements/style.spec.ts
@@ -10,7 +10,9 @@ import * as Stories from './style.stories.js'
 
 const {
   StaticValue,
-  ReactiveValue
+  ReactiveValue,
+  MultiWordValue,
+  CustomProperty
 } = composeStories(Stories)
 
 describe('nanoviews', () => {
@@ -33,6 +35,32 @@ describe('nanoviews', () => {
         color('red')
 
         expect(container.innerHTML).toBe('<div><div style="color: red;">Hello, world!</div></div>')
+      })
+
+      it('should render custom properties', () => {
+        const color = signal('green')
+        const { container } = render(CustomProperty({
+          color
+        }))
+
+        expect(container.innerHTML).toBe('<div><div style="--accent: green; --gap: 4px;">Hello, world!</div></div>')
+
+        color('red')
+
+        expect(container.innerHTML).toBe('<div><div style="--accent: red; --gap: 4px;">Hello, world!</div></div>')
+      })
+
+      it('should render multi-word properties', () => {
+        const color = signal('green')
+        const { container } = render(MultiWordValue({
+          color
+        }))
+
+        expect(container.innerHTML).toBe('<div><div style="background-color: green; font-size: 12px;">Hello, world!</div></div>')
+
+        color('red')
+
+        expect(container.innerHTML).toBe('<div><div style="background-color: red; font-size: 12px;">Hello, world!</div></div>')
       })
     })
   })

--- a/packages/nanoviews/src/elements/style.stories.ts
+++ b/packages/nanoviews/src/elements/style.stories.ts
@@ -34,3 +34,27 @@ export const ReactiveValue: Story = {
     }
   })('Hello, world!'))
 }
+
+export const CustomProperty: Story = {
+  args: {
+    color: 'green'
+  },
+  render: nanoStory(({ color }) => div({
+    [style$]: {
+      '--accent': color,
+      '--gap': '4px'
+    }
+  })('Hello, world!'))
+}
+
+export const MultiWordValue: Story = {
+  args: {
+    color: 'green'
+  },
+  render: nanoStory(({ color }) => div({
+    [style$]: {
+      backgroundColor: color,
+      fontSize: '12px'
+    }
+  })('Hello, world!'))
+}

--- a/packages/nanoviews/src/elements/style.ts
+++ b/packages/nanoviews/src/elements/style.ts
@@ -1,23 +1,55 @@
 import {
+  isAccessor,
+  effect
+} from 'kida'
+import {
   type CSSProperties,
   type AccessibleProps,
   type PrimitiveAttributeValue,
-  setProperty,
+  type Primitive,
   createEffectAttribute
 } from '../internals/index.js'
 
 export type StyleProps = AccessibleProps<CSSProperties>
+
+// Every camelCased CSS property is a real writable property of
+// `CSSStyleDeclaration`, but it declares no string index signature
+type StyleDeclaration = CSSStyleDeclaration & Record<string, string>
+
+// `CSSProperties` is camelCased, while `setProperty` matches its argument
+// against the hyphenated CSS property names only and silently drops
+// everything else, so the assignment is the writer that accepts the names this
+// attribute is typed with - except for custom properties, which the assignment
+// does not see at all. An empty value removes the property either way, so
+// there is nothing to branch on
+function setStyleValue(
+  style: StyleDeclaration,
+  name: string,
+  value: Primitive
+) {
+  const cssValue = value as string ?? ''
+
+  if (name.startsWith('--')) {
+    style.setProperty(name, cssValue)
+  } else {
+    style[name] = cssValue
+  }
+}
 
 function setStyle(
   element: HTMLElement | SVGAElement,
   name: string,
   $value: PrimitiveAttributeValue
 ) {
-  setProperty(
-    value => element.style.setProperty(name, value),
-    () => element.style.removeProperty(name),
-    $value
-  )
+  const style = element.style as StyleDeclaration
+
+  if (isAccessor($value)) {
+    effect(() => {
+      setStyleValue(style, name, $value())
+    }, true)
+  } else {
+    setStyleValue(style, name, $value)
+  }
 }
 
 /**

--- a/packages/nanoviews/src/internals/types/dom/attributes.ts
+++ b/packages/nanoviews/src/internals/types/dom/attributes.ts
@@ -17,13 +17,14 @@ import type {
 
 export interface CSSProperties extends CSS.Properties<string | number> {
   /**
-   * The index signature was removed to enable closed typing for style
-   * using CSSType. You're able to use type assertion or module augmentation
-   * to add properties or an index signature of your own.
+   * Custom properties are the only open part of the typing: every other name
+   * is checked against CSSType. You're able to use type assertion or module
+   * augmentation to add properties of your own.
    *
    * For examples and more information, visit:
    * https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors
    */
+  [name: `--${string}`]: string | number | undefined
 }
 
 export interface HTMLAttributes<T extends Node = Node> extends AriaAttributes, DOMAttributes<T> {


### PR DESCRIPTION
`style$` never applied multi-word CSS properties in a real browser, and the test suite could not see it.

## The bug

The writer went through `style.setProperty(name, value)`. Per CSSOM, `setProperty` lowercases its argument and then requires a **case-sensitive match against a supported CSS property name** — which are the hyphenated ones. `CSSProperties` is csstype's camelCased `CSS.Properties`, so every multi-word name failed that check and returned silently.

Verified in Chrome 148:

| call | result |
|---|---|
| `setProperty('color', 'green')` | `color: green` ✔ |
| `setProperty('backgroundColor', 'red')` | **no-op** |
| `setProperty('fontSize', '12px')` | **no-op** |
| `setProperty('zIndex', '5')` | **no-op** |
| `setProperty('borderTopWidth', '3px')` | **no-op** |
| `setProperty('background-color', 'red')` | `background-color: red` ✔ |

So only single-word properties ever worked. `removeProperty('backgroundColor')` is a no-op too, which means a reactive multi-word property could neither be set nor cleared.

## Why the suite stayed green

happy-dom implements `setProperty` as `String(value).trim()` truthiness with no supported-property gate, so it stores `backgroundColor` verbatim and reports success. The only spec covering `style$` used `color`, which works in both. The new spec renders `backgroundColor` and `fontSize` and fails against the old writer:

```
- Expected: <div style="background-color: green; font-size: 12px;">
+ Received: <div style="backgroundColor: green; fontSize: 12px;">
```

## The fix

Values go through property assignment, which accepts exactly the camelCased names this attribute is typed with, and also handles vendor prefixes and hyphenated names.

`?? ''` is load-bearing rather than cosmetic. Assigning `null` clears a property, but assigning `undefined` stringifies to `"undefined"` and is ignored as an invalid value, leaving the old one in place — both verified in Chrome and happy-dom.

## Custom properties

Property assignment cannot see `--*` names, so they keep going through `setProperty`, where they work: custom properties skip the supported-property gate and are case-sensitive. `CSSProperties` gains a template-literal index signature for them; the closed CSSType typing of every other name is unchanged.

End-to-end check on the built bundle in Chrome 148: static `fontSize` and reactive `backgroundColor` both apply, computed values are correct, and writing to the signal repaints. Before the fix none of it worked except `color`.
