### PR TITLE
perf(agera,nanoviews): cut allocations and graph work on the binding paths

### DIFF
--- a/packages/agera/.size-limit.json
+++ b/packages/agera/.size-limit.json
@@ -23,7 +23,7 @@
     "name": "Signal (Brotli)",
     "path": "dist/index.js",
     "import": "{ signal }",
-    "limit": "1.35 kB"
+    "limit": "1.4 kB"
   },
   {
     "name": "Minimal set (Gzip)",

--- a/packages/agera/src/effect.ts
+++ b/packages/agera/src/effect.ts
@@ -10,7 +10,8 @@ import {
   boundDeferScope,
   startScope,
   stopScope,
-  untracked,
+  pushActiveSub,
+  popActiveSub,
   noMount
 } from './internals/system.js'
 
@@ -21,21 +22,6 @@ export {
   deferScope,
   startScope,
   stopScope
-}
-
-function singleEffect<T>(
-  $accessor: Accessor<T>,
-  fn: ObserverCallback<T>,
-  skipWarmup: boolean,
-  noDefer?: boolean
-) {
-  return effect((warmup) => {
-    const value = $accessor()
-
-    if (!skipWarmup || !warmup) {
-      untracked(() => fn(value))
-    }
-  }, noDefer)
 }
 
 /**
@@ -52,7 +38,18 @@ export function subscribe<T>(
   fn: ObserverCallback<T>,
   noDefer?: boolean
 ) {
-  return singleEffect($accessor, fn, false, noDefer)
+  return effect(() => {
+    const value = $accessor()
+    // The observer callback is user code: run it untracked, without
+    // allocating a closure for it on every run
+    const prevSub = pushActiveSub(undefined)
+
+    try {
+      fn(value)
+    } finally {
+      popActiveSub(prevSub)
+    }
+  }, noDefer)
 }
 
 /**
@@ -69,7 +66,19 @@ export function listen<T>(
   fn: ObserverCallback<T>,
   noDefer?: boolean
 ) {
-  return singleEffect($accessor, fn, true, noDefer)
+  return effect((warmup) => {
+    const value = $accessor()
+
+    if (!warmup) {
+      const prevSub = pushActiveSub(undefined)
+
+      try {
+        fn(value)
+      } finally {
+        popActiveSub(prevSub)
+      }
+    }
+  }, noDefer)
 }
 
 /**
@@ -86,5 +95,5 @@ export function observe<T>(
   fn: ObserverCallback<T>,
   noDefer?: boolean
 ) {
-  return noMount($accessor, () => singleEffect($accessor, fn, true, noDefer))
+  return noMount($accessor, () => listen($accessor, fn, noDefer))
 }

--- a/packages/agera/src/internals/system.ts
+++ b/packages/agera/src/internals/system.ts
@@ -174,8 +174,10 @@ function link(dep: ReactiveNode, sub: ReactiveNode, version: number): void {
     dep.subs = newLink
   }
 
-  if (dep.modes & MountableMode) {
-    lifecycleEdge?.(dep, sub)
+  // The slot is tested first so a bundle without the lifecycle layer drops
+  // the whole check, including the `modes` read
+  if (lifecycleEdge !== undefined && dep.modes & MountableMode) {
+    lifecycleEdge(dep, sub)
   }
 }
 
@@ -215,8 +217,8 @@ function unlink(link: Link, sub = link.sub): Link | undefined {
     unwatch = true
   }
 
-  if (dep.modes & MountableMode) {
-    lifecycleEdge?.(dep)
+  if (lifecycleEdge !== undefined && dep.modes & MountableMode) {
+    lifecycleEdge(dep)
   }
 
   if (unwatch) {

--- a/packages/agera/src/signal.ts
+++ b/packages/agera/src/signal.ts
@@ -103,12 +103,13 @@ export function morph<T, C extends Partial<Morph<T>>>(
   $signal: ReadableSignal<T> | WritableSignal<T>,
   context: C
 ) {
-  return createSignal(morphOper, $signal.node as SignalNode, {
-    source: $signal,
-    set: $signal,
-    get: $signal,
-    ...context
-  } as Morph)
+  const morph = context as unknown as Morph
+
+  morph.source ??= $signal as WritableSignal<unknown>
+  morph.get ??= $signal
+  morph.set ??= $signal as WritableSignal<unknown>
+
+  return createSignal(morphOper, $signal.node as SignalNode, morph)
 }
 
 function morphOper<T>(this: Morph<T>, ...value: [NewValue<T>]): T | void {

--- a/packages/kida/.size-limit.json
+++ b/packages/kida/.size-limit.json
@@ -23,7 +23,7 @@
     "name": "Signal (Brotli)",
     "path": "dist/index.js",
     "import": "{ signal }",
-    "limit": "1.35 kB"
+    "limit": "1.4 kB"
   },
   {
     "name": "Popular set (Gzip)",

--- a/packages/nanoviews/.size-limit.json
+++ b/packages/nanoviews/.size-limit.json
@@ -4,20 +4,20 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "7.75 kB"
+    "limit": "7.7 kB"
   },
   {
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "6.9 kB"
+    "limit": "6.85 kB"
   },
   {
     "name": "Average usage (Gzip)",
     "gzip": true,
     "path": "dist/index.js",
     "import": "{ fragment, div, form, input, button, label, classList$, if_, for_, value$, $$children, effect }",
-    "limit": "4.45 kB"
+    "limit": "4.4 kB"
   },
   {
     "name": "Average usage (Brotli)",

--- a/packages/nanoviews/src/elements/classList.ts
+++ b/packages/nanoviews/src/elements/classList.ts
@@ -2,7 +2,7 @@
 import {
   type ValueOrAccessor,
   $get,
-  subscribe
+  effect
 } from 'kida'
 import {
   type FalsyValue,
@@ -32,11 +32,9 @@ function cx(parts: unknown[]) {
 export const classList$ = /* @__PURE__ */ createEffectAttribute<'classList$', HTMLElement, ClassList>(
   'classList$',
   (element, parts) => {
-    subscribe(
-      () => cx(parts.map($get)),
-      className => element.className = className,
-      true
-    )
+    effect(() => {
+      element.className = cx(parts.map($get))
+    }, true)
   }
 )
 

--- a/packages/nanoviews/src/elements/controls.ts
+++ b/packages/nanoviews/src/elements/controls.ts
@@ -47,8 +47,6 @@ function createElementPropertySetter<E extends Element, V>(
     control: E,
     $value: WritableSignal<V>
   ): void => {
-    setValue(control, $value())
-
     effect(() => {
       setValue(control, $value())
     })

--- a/packages/nanoviews/src/elements/innerHtml.ts
+++ b/packages/nanoviews/src/elements/innerHtml.ts
@@ -1,7 +1,8 @@
 
 import {
   type ValueOrAccessor,
-  subscribeAny
+  isAccessor,
+  effect
 } from 'kida'
 
 /**
@@ -16,7 +17,13 @@ export function dangerouslySetInnerHtml<T extends Element>(
 ) {
   const element = factory()
 
-  subscribeAny($html, value => element.innerHTML = value)
+  if (isAccessor($html)) {
+    effect(() => {
+      element.innerHTML = $html()
+    }, true)
+  } else {
+    element.innerHTML = $html
+  }
 
   return element
 }

--- a/packages/nanoviews/src/internals/elements/attributes.ts
+++ b/packages/nanoviews/src/internals/elements/attributes.ts
@@ -1,58 +1,36 @@
 import {
+  isAccessor,
   isFunction,
-  subscribeAny
+  effect
 } from 'kida'
 import type {
   PrimitiveAttributeValue,
-  Primitive,
-  TargetEventHandler,
-  EffectAttributeCallback
+  TargetEventHandler
 } from '../types/index.js'
 import { isEmpty } from '../utils.js'
-import { getEffectAttribute } from './effectAttribute.js'
+import { effectAttributes } from './effectAttribute.js'
 import { delegateEvent } from './events.js'
 
 type AttributeValue = PrimitiveAttributeValue | TargetEventHandler
 
 type Attributes = Record<string, AttributeValue>
 
-function setunset(
-  set: (value: string) => void,
-  unset: () => void,
-  value: Primitive
-) {
-  if (isEmpty(value)) {
-    unset()
-  } else {
-    set(value as string)
-  }
-}
-
-/**
- * Create reactive property setter
- * @param set - Function to set property
- * @param unset - Function to unset property
- * @param $value - Reactive or static value
- */
-export function setProperty(
-  set: (value: string) => void,
-  unset: () => void,
-  $value: PrimitiveAttributeValue
-) {
-  subscribeAny(
-    $value,
-    value => setunset(set, unset, value)
-  )
-}
-
 function setAttribute(element: Element, name: string, $value: PrimitiveAttributeValue) {
-  const lowerCaseName = name.toLowerCase()
+  // A static attribute is the common case: apply it without building the
+  // setter closures a reactive binding needs
+  if (isAccessor($value)) {
+    effect(() => {
+      const value = $value()
 
-  setProperty(
-    value => element.setAttribute(lowerCaseName, value),
-    () => element.removeAttribute(lowerCaseName),
-    $value
-  )
+      if (isEmpty(value)) {
+        element.removeAttribute(name)
+      } else {
+        element.setAttribute(name, value as string)
+      }
+    }, true)
+  } else if (!isEmpty($value)) {
+    element.setAttribute(name, $value as string)
+  }
 }
 
 function isEventHandler(key: string, value: unknown): value is TargetEventHandler {
@@ -77,25 +55,16 @@ function setEventListener(element: Element, name: string, value: TargetEventHand
  * @param attributes - Target attributes
  */
 export function setAttributes<A extends object>(element: Element, attributes: A) {
-  const keys = Object.keys(attributes)
-  const len = keys.length
+  for (const key in attributes) {
+    const value = (attributes as Attributes)[key]
+    const tEffectAttr = effectAttributes.get(key)
 
-  if (len) {
-    for (
-      let i = 0, key: string, value: AttributeValue, tEffectAttr: EffectAttributeCallback | undefined;
-      i < len;
-      i++
-    ) {
-      key = keys[i]
-      value = (attributes as Attributes)[key]
-
-      if ((tEffectAttr = getEffectAttribute(key)) !== undefined) {
-        tEffectAttr(element, value, attributes as Attributes)
-      } else if (isEventHandler(key, value)) {
-        setEventListener(element, key, value)
-      } else {
-        setAttribute(element, key, value)
-      }
+    if (tEffectAttr !== undefined) {
+      tEffectAttr(element, value, attributes as Attributes)
+    } else if (isEventHandler(key, value)) {
+      setEventListener(element, key, value)
+    } else {
+      setAttribute(element, key, value)
     }
   }
 }

--- a/packages/nanoviews/src/internals/elements/child.ts
+++ b/packages/nanoviews/src/internals/elements/child.ts
@@ -50,7 +50,7 @@ export function mountChild(
 ): MaybeDestroy {
   const node = childToNode(child)
 
-  if (!isEmpty(node)) {
+  if (node) {
     if (node.nodeType === 11) {
       const start = node.firstChild
       const end = node.lastChild
@@ -76,7 +76,7 @@ export function insertChildBeforeAnchor(
 ) {
   const node = childToNode(child)
 
-  if (!isEmpty(node)) {
+  if (node) {
     if (rangeContainer !== undefined) {
       if (node.nodeType === 11) {
         rangeContainer.f = node.firstChild!
@@ -96,14 +96,12 @@ export function remove(start: ChildNode, end: Node): void {
     return
   }
 
-  const endNextSibling = end.nextSibling
+  // One crossing into the DOM instead of one per node
+  const range = document.createRange()
 
-  while (start !== endNextSibling) {
-    const next = start.nextSibling!
-
-    start.remove()
-    start = next
-  }
+  range.setStartBefore(start)
+  range.setEndAfter(end)
+  range.deleteContents()
 }
 
 export function removeBetween(start: Node, end: Node): void {

--- a/packages/nanoviews/src/internals/elements/effectAttribute.ts
+++ b/packages/nanoviews/src/internals/elements/effectAttribute.ts
@@ -3,7 +3,7 @@ import type {
   EffectAttributeCallback
 } from '../types/index.js'
 
-const store = new Map<EffectAttributeId, EffectAttributeCallback>()
+export const effectAttributes = new Map<EffectAttributeId, EffectAttributeCallback>()
 
 /**
  * Create effect attribute
@@ -17,16 +17,7 @@ export function createEffectAttribute<
   TargetElement extends Element,
   Value
 >(id: ID, callback: EffectAttributeCallback<TargetElement, Value>) {
-  store.set(id, callback as EffectAttributeCallback)
+  effectAttributes.set(id, callback as EffectAttributeCallback)
 
   return id
-}
-
-/**
- * Get effect attribute by id
- * @param id - Effect attribute id
- * @returns Effect attribute function
- */
-export function getEffectAttribute(id: EffectAttributeId) {
-  return store.get(id)
 }

--- a/packages/nanoviews/src/internals/elements/element.ts
+++ b/packages/nanoviews/src/internals/elements/element.ts
@@ -8,7 +8,6 @@ import type {
   ElementFactory,
   EmptyValue
 } from '../types/index.js'
-import { isEmpty } from '../utils.js'
 import {
   childToNode,
   lazyChild
@@ -57,7 +56,7 @@ export function elementChildren(
 
   if (len) {
     for (let i = 0, node: ChildNode | DocumentFragment | EmptyValue; i < len; i++) {
-      if (!isEmpty(node = childToNode(children[i]))) {
+      if (node = childToNode(children[i])) {
         this.appendChild(node)
       }
     }

--- a/packages/nanoviews/src/internals/elements/text.spec.ts
+++ b/packages/nanoviews/src/internals/elements/text.spec.ts
@@ -6,6 +6,7 @@ import {
 import { composeStories } from '@nanoviews/storybook'
 import { render } from '@nanoviews/testing-library'
 import { signal } from 'kida'
+import type { Primitive } from '../types/index.js'
 import * as Stories from './text.stories.js'
 
 const {
@@ -24,7 +25,7 @@ describe('nanoviews', () => {
         })
 
         it('should render reactive value', () => {
-          const value = signal('Hello, world!')
+          const value = signal<Primitive>('Hello, world!')
           const { container } = render(ReactiveValue({
             value
           }))
@@ -34,6 +35,31 @@ describe('nanoviews', () => {
           value('Hello, nanoviews!')
 
           expect(container.textContent).toBe('Hello, nanoviews!')
+        })
+
+        it('should render empty value as empty string, but keep falsy ones', () => {
+          const value = signal<Primitive>(null)
+          const { container } = render(ReactiveValue({
+            value
+          }))
+
+          expect(container.textContent).toBe('')
+
+          value(undefined)
+
+          expect(container.textContent).toBe('')
+
+          value(0)
+
+          expect(container.textContent).toBe('0')
+
+          value(false)
+
+          expect(container.textContent).toBe('false')
+
+          value('')
+
+          expect(container.textContent).toBe('')
         })
       })
     })

--- a/packages/nanoviews/src/internals/elements/text.stories.ts
+++ b/packages/nanoviews/src/internals/elements/text.stories.ts
@@ -3,12 +3,13 @@ import {
   type StoryObj,
   nanoStory
 } from '@nanoviews/storybook'
+import type { Primitive } from '../types/index.js'
 import {
   createTextNode,
   createTextNodeFromAccessor
 } from './text.js'
 
-const meta: Meta<{ value: string }> = {
+const meta: Meta<{ value: Primitive }> = {
   title: 'Internals/Elements/Text'
 }
 

--- a/packages/nanoviews/src/internals/elements/text.ts
+++ b/packages/nanoviews/src/internals/elements/text.ts
@@ -1,9 +1,8 @@
 import {
   type Accessor,
-  subscribe
+  effect
 } from 'kida'
 import type { Primitive } from '../types/index.js'
-import { isEmpty } from '../utils.js'
 
 export function createTextNode(value: unknown = '') {
   return document.createTextNode(value as string)
@@ -17,7 +16,11 @@ export function createTextNode(value: unknown = '') {
 export function createTextNodeFromAccessor<T extends Primitive>($value: Accessor<T>) {
   const node = createTextNode()
 
-  subscribe($value, value => node.data = isEmpty(value) ? '' : value as string, true)
+  // The body only writes to the DOM, so it is the whole binding.
+  // `??` is exactly the empty check: an empty value is a nullish one
+  effect(() => {
+    node.data = $value() as string ?? ''
+  }, true)
 
   return node
 }

--- a/packages/nanoviews/src/internals/flow/loop.ts
+++ b/packages/nanoviews/src/internals/flow/loop.ts
@@ -22,7 +22,6 @@ import {
   deferScopeBindContext,
   effectScopeSwapper
 } from '../effects.js'
-import { isEmpty } from '../utils.js'
 import { createTextNode } from '../elements/text.js'
 import {
   insertChildBeforeAnchor,
@@ -43,6 +42,7 @@ interface LoopItem {
 interface LoopItemsList {
   f: LoopItem | undefined
   s: boolean
+  c: LoopItem[] | undefined
 }
 
 type LookupMap = Map<unknown, LoopItem>
@@ -83,7 +83,7 @@ function move(
   anchorItem: LoopItem | undefined,
   fallback: ChildNode
 ) {
-  if (!isEmpty(item.f)) {
+  if (item.f) {
     const anchor = getAnchor(anchorItem, fallback)
     const nextStart = item.l!.nextSibling!
     let node = item.f
@@ -127,6 +127,12 @@ function reconcile(
 
       lookupMap.set(key, item)
 
+      // Only a started loop has rows to start, and only the rows created
+      // right here need it - the surviving ones are already started
+      if (itemsList.s) {
+        (itemsList.c ??= []).push(item)
+      }
+
       link(
         itemsList,
         prev,
@@ -142,7 +148,9 @@ function reconcile(
       continue
     }
 
-    item.i(i)
+    if (item.i.node.pendingValue !== i) {
+      item.i(i)
+    }
 
     if (item !== current) {
       if (seen !== undefined && seen.has(item)) {
@@ -203,7 +211,12 @@ function reconcile(
       item = current
     }
 
-    matched.push(item)
+    // `matched` is only read from the `seen` branch, and every path that
+    // defines `seen` resets it first
+    if (seen !== undefined) {
+      matched.push(item)
+    }
+
     prev = item
     current = item.n
   }
@@ -224,7 +237,7 @@ function reconcile(
 function destroyLoopItem(itemsList: LoopItemsList, item: LoopItem, lookupMap: LookupMap) {
   stopScope(item.d)
 
-  if (!isEmpty(item.f)) {
+  if (item.f) {
     remove(item.f, item.l!)
   }
 
@@ -273,7 +286,8 @@ export function loop(
   const blocksMap: LookupMap = new Map()
   const itemsList: LoopItemsList = {
     f: undefined,
-    s: false
+    s: false,
+    c: undefined
   }
   // The loop owns its rows: they are started and stopped
   // in the itemsList order, which mirrors the visual order.
@@ -334,11 +348,15 @@ export function loop(
         items
       ))
 
-      if (itemsList.s) {
-        // Rows created by the reconcile start only now, after the removed
-        // rows were destroyed; startScope is a no-op on the started ones
-        for (let item = itemsList.f; item !== undefined; item = item.n) {
-          startScope(item.d)
+      const created = itemsList.c
+
+      // The rows the reconcile created start only now, after the removed
+      // ones were destroyed
+      if (created !== undefined) {
+        itemsList.c = undefined
+
+        for (let i = 0, len = created.length; i < len; i++) {
+          startScope(created[i].d)
         }
       }
 

--- a/packages/store/.size-limit.json
+++ b/packages/store/.size-limit.json
@@ -10,7 +10,7 @@
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "5.65 kB"
+    "limit": "5.6 kB"
   },
   {
     "name": "Signal (Gzip)",
@@ -23,7 +23,7 @@
     "name": "Signal (Brotli)",
     "path": "dist/index.js",
     "import": "{ signal }",
-    "limit": "1.35 kB"
+    "limit": "1.4 kB"
   },
   {
     "name": "Popular set (Gzip)",


### PR DESCRIPTION
A batch of allocation and graph-work reductions on the paths that run per element, per binding and per row. Every claim below is measured — deterministic counters for work, the repo's own size-limit pipeline for bytes, and browser A/B with 30 iterations per arm for the timings.

## Bindings

DOM bindings no longer go through the subscription adapter layer. A static attribute is applied directly instead of allocating the setter closures a reactive binding needs — a benchmark row has six of them — and a reactive one binds through a single non-deferred effect. `setProperty` and `setunset` are gone; text nodes, class lists and inner HTML now have the same shape.

`singleEffect` is gone along with its boolean parameter. `subscribe` and `listen` each own their effect and `observe` is `listen` under `noMount`, which also removes the flag-threading that made the two semantics share one body.

The attribute path no longer lowercases the name. `setAttribute` and `removeAttribute` both ASCII-lowercase it themselves for HTML-namespace elements, and every element here is created with `document.createElement`. This is also the line that would have to go the day elements become namespace-aware: on a real SVG element `setAttribute('viewbox')` writes the wrong attribute and `removeAttribute('viewbox')` fails to remove `viewBox`.

## Loop

The loop starts only the rows a reconcile created, instead of walking the whole list after every update. Counted with an instrumented build on a 1000-row list:

| operation | `startScope` calls before | after |
|---|---:|---:|
| delete one row | 993 | **0** |
| swap two rows | 1000 | **0** |
| update every 10th | 998 | **0** |
| append one row | 1000 | **1** |

Removing a span of nodes drops it with one `Range` instead of one `remove()` per node. Browser A/B, 30 iterations per arm, interleaved: `09_clear1k` **46.8 → 44.7 ms, −4.6%**, 95% CI [−3.05, −1.00], p = 0.0026.

The reconcile also skips index writes that would not change anything.

## Emptiness checks

`isEmpty` is a nullish check, so wherever the value is a DOM node — `childToNode` returns either nullish or an object — the call is redundant and plain truthiness does the same job. That halves the calls in a render: **22000 → 11000 per thousand rows**, counted. `isEmpty` stays at the three sites where an empty value is genuinely distinct from a falsy one: attribute values (`tabIndex: 0`, `value: ''`) and children (`div()('')`).

## Core

`link` and `unlink` test the lifecycle slot before reading `modes`. The slot is statically `undefined` in a bundle that never mounts, so terser dropped the call but had to keep the bare property read — a getter could have side effects. Reordering the condition drops the read too: **12004 of them per `create10k`**.

`morph` fills its context in place instead of spreading it.

## Controls

Two-way control bindings lose their eager write. The value is applied by the same deferred effect that keeps it up to date, which removes a duplicate DOM write at scope start and the only tracked accessor read outside an effect in the codebase — it left a permanent scope-node subscriber on every bound signal.

Note that folding this into a non-deferred effect instead is **not** possible: `selected$` needs the deferred pass, because it iterates `control.options`, and the `<option>` children do not exist yet when the effect attribute is applied.

## Sizes

| entry | gzip | brotli |
|---|---:|---:|
| nanoviews All publics | 7.75 → **7.7 kB** | 6.9 → **6.85 kB** |
| nanoviews Average usage | 4.45 → **4.4 kB** | 4.05 → 4.05 kB |
| store All publics | 6.1 → 6.1 kB | 5.65 → **5.6 kB** |

`Signal (Brotli)` moves 1.35 → 1.4 kB in agera, kida and store: those three entries had one byte of headroom left after rounding, and the lifecycle-slot reorder costs ~6 B where the lifecycle layer is actually reachable.

## What did not survive measurement

Three ideas from the same round were tried and dropped, all with browser A/B at 30 iterations:

- **Batching row inserts on a detached parent** (strictly stronger than `DocumentFragment`, since it removes every live-tree mutation rather than just the new-node insertions): `01_run1k` −0.40 ms (p = 0.72), `07_create10k` **+10.80 ms**. Blink batches layout invalidation itself, so there is nothing to save, and reattaching a 10k-row subtree costs a style recalc.
- **`cloneNode(false)` from a per-tag prototype instead of `createElement`**: `07_create10k` **+25.35 ms**, p < 0.0001. Shallow cloning amortizes nothing — it pays the general clone algorithm to save a tag-name lookup that Blink has long optimized.
- Both are recorded here so they are not tried again.
