### PR TITLE
refactor(agera,kida,store): replace `morph` with the signal constructor protocol

### DIFF
--- a/packages/agera/.size-limit.json
+++ b/packages/agera/.size-limit.json
@@ -23,7 +23,7 @@
     "name": "Signal (Brotli)",
     "path": "dist/index.js",
     "import": "{ signal }",
-    "limit": "1.4 kB"
+    "limit": "1.35 kB"
   },
   {
     "name": "Minimal set (Gzip)",

--- a/packages/agera/README.md
+++ b/packages/agera/README.md
@@ -293,28 +293,6 @@ $a(1)
 $b(2)
 ```
 
-### Morph
-
-`morph` methods allows to create signals that can change their getter and setter on the fly.
-
-```ts
-import { signal, morph } from 'agera'
-
-const $string = signal('')
-// Debounce signal updates
-const $debouncedString = morph($string, {
-  set: debounce($string, 300)
-})
-// Lazy initialization
-const $lazyString = morph($string, {
-  get() {
-    this.set('Lazy string')
-    this.get = this.source
-    return 'Lazy string'
-  }
-})
-```
-
 ### `isSignal`
 
 `isSignal` method checks if the value is a signal.

--- a/packages/agera/src/index.ts
+++ b/packages/agera/src/index.ts
@@ -1,9 +1,15 @@
 export type * from './internals/types.js'
-export { ExternalModesBase } from './internals/flags.js'
+export {
+  NoneFlag,
+  WritableMode,
+  ExternalModesBase
+} from './internals/flags.js'
 export {
   untracked,
   trigger,
-  onSignal
+  onSignal,
+  createSignal,
+  computedOper
 } from './internals/system.js'
 export * from './signal.js'
 export * from './modes.js'

--- a/packages/agera/src/internals/system.ts
+++ b/packages/agera/src/internals/system.ts
@@ -14,7 +14,6 @@ import type {
   Destroy,
   Compute,
   NewValue,
-  Morph,
   DeferredScope
 } from './types.js'
 import {
@@ -431,12 +430,20 @@ export function onSignal(callback: ($signal: AnySignal) => void) {
     : callback
 }
 
-export function createSignal(
-  constructor: (value?: unknown) => unknown,
-  node: ComputedNode | SignalNode,
-  ctx: ComputedNode | SignalNode | Morph = node
+/**
+ * Create a signal function over a reactive node. The node is the operator's
+ * `this`, so whatever a call site needs at read or write time lives on the
+ * node and a signal costs one object and one bound function, nothing else.
+ * @private
+ * @param constructor - The operator: called with no arguments to read, with one to write.
+ * @param node - The node the signal is a face of.
+ * @returns A signal.
+ */
+export function createSignal<N extends ComputedNode | SignalNode>(
+  constructor: (this: N, ...value: any[]) => unknown,
+  node: N
 ) {
-  const $signal = constructor.bind(ctx) as AnySignal
+  const $signal = constructor.bind(node) as AnySignal
 
   $signal.node = node
 
@@ -713,7 +720,14 @@ function flush(): void {
   }
 }
 
-function computedOper<T>(this: ComputedNode<T>): T {
+/**
+ * The read operator of a computed node. Exported so that a call site can put
+ * its own operator in front of one: a writable computed is this one with a
+ * write branch before it.
+ * @private
+ * @returns The current value.
+ */
+export function computedOper<T>(this: ComputedNode<T>): T {
   const flags = this.flags
 
   if (

--- a/packages/agera/src/internals/types.ts
+++ b/packages/agera/src/internals/types.ts
@@ -66,12 +66,6 @@ export interface ReadableSignal<T> extends Accessor<T> {
   node: ReadableNode
 }
 
-export interface Morph<T = unknown> {
-  source: WritableSignal<T>
-  get(): T
-  set(value: NewValue<T>): void
-}
-
 export interface WritableSignal<T> extends ReadableSignal<T> {
   node: SignalNode<T>
   (value: NewValue<T>): void

--- a/packages/agera/src/signal.spec.ts
+++ b/packages/agera/src/signal.spec.ts
@@ -5,11 +5,12 @@ import {
   expect
 } from 'vitest'
 import {
+  type SignalNode,
   computed,
   signal,
   effect,
   isSignal,
-  morph,
+  createSignal,
   trigger
 } from './index.js'
 
@@ -120,12 +121,32 @@ describe('agera', () => {
       })
     })
 
-    describe('morph', () => {
-      it('should pass isSignal check', () => {
-        const $num = signal(0)
-        const $morph = morph($num, {})
+    describe('createSignal', () => {
+      it('should create a second face over the same node', () => {
+        const $num = signal(1)
+        const node = $num.node as SignalNode<number> & {
+          get(): number
+          set(value: number): void
+        }
 
-        expect(isSignal($morph)).toBe(true)
+        node.get = () => $num() * 2
+        node.set = value => $num(value / 2)
+
+        const $double = createSignal(function doubleOper(this: typeof node, ...value: [number]) {
+          if (value.length) {
+            this.set(value[0])
+          } else {
+            return this.get()
+          }
+        }, node)
+
+        expect(isSignal($double)).toBe(true)
+        expect($double.node).toBe($num.node)
+        expect($double()).toBe(2)
+
+        $double(10)
+
+        expect($num()).toBe(5)
       })
     })
 

--- a/packages/agera/src/signal.ts
+++ b/packages/agera/src/signal.ts
@@ -1,20 +1,14 @@
 import type {
   AnySignal,
   Destroy,
-  Morph,
   Mountable,
   MountedListener,
-  NewValue,
-  ReadableNode,
-  ReadableSignal,
-  SignalNode,
-  WritableSignal
+  ReadableNode
 } from './internals/types.js'
 import {
   signal,
   computed,
   batch,
-  createSignal,
   nextValue,
   signalNextValue,
   touchLifecycle,
@@ -86,36 +80,4 @@ export function onMounted(
  */
 export function isMounted($signal: AnySignal): boolean {
   return ($signal.node as ReadableNode).lcd === true
-}
-
-export function morph<T, C extends Partial<Morph<T>>>(
-  $signal: WritableSignal<T>,
-  context: C
-): WritableSignal<T>
-
-export function morph<T, C extends Partial<Morph<T>>>(
-  $signal: ReadableSignal<T>,
-  context: C
-): ReadableSignal<T>
-
-/* @__NO_SIDE_EFFECTS__ */
-export function morph<T, C extends Partial<Morph<T>>>(
-  $signal: ReadableSignal<T> | WritableSignal<T>,
-  context: C
-) {
-  const morph = context as unknown as Morph
-
-  morph.source ??= $signal as WritableSignal<unknown>
-  morph.get ??= $signal
-  morph.set ??= $signal as WritableSignal<unknown>
-
-  return createSignal(morphOper, $signal.node as SignalNode, morph)
-}
-
-function morphOper<T>(this: Morph<T>, ...value: [NewValue<T>]): T | void {
-  if (value.length) {
-    this.set(value[0])
-  } else {
-    return this.get()
-  }
 }

--- a/packages/kida/.size-limit.json
+++ b/packages/kida/.size-limit.json
@@ -10,7 +10,7 @@
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "4.2 kB"
+    "limit": "4.25 kB"
   },
   {
     "name": "Signal (Gzip)",
@@ -23,19 +23,19 @@
     "name": "Signal (Brotli)",
     "path": "dist/index.js",
     "import": "{ signal }",
-    "limit": "1.4 kB"
+    "limit": "1.35 kB"
   },
   {
     "name": "Popular set (Gzip)",
     "gzip": true,
     "path": "dist/index.js",
     "import": "{ signal, record, computed, effect, mountable, onMount }",
-    "limit": "2.45 kB"
+    "limit": "2.4 kB"
   },
   {
     "name": "Popular set (Brotli)",
     "path": "dist/index.js",
     "import": "{ signal, record, computed, effect, mountable, onMount }",
-    "limit": "2.3 kB"
+    "limit": "2.25 kB"
   }
 ]

--- a/packages/kida/src/internals/child.ts
+++ b/packages/kida/src/internals/child.ts
@@ -1,17 +1,54 @@
 import {
   type WritableSignal,
   type ReadableSignal,
+  type ComputedNode,
   type Accessor,
   type NewValue,
-  computed,
-  morph,
+  NoneFlag,
+  WritableMode,
+  computedOper,
+  createSignal,
   isWritable,
-  unsafeMarkWritable,
   nextValue,
   untracked
 } from 'agera'
 import type { AnyObject } from './types.js'
 import { $get } from './utils.js'
+
+// A child is one node and one bound function: the parent, the key and the
+// writer live on the node the operators are bound to, so nothing here
+// allocates a closure per child
+interface ChildNode extends ComputedNode {
+  /**
+   * Parent signal.
+   */
+  p: WritableSignal<AnyObject>
+  /**
+   * Key to read from the parent, static or reactive.
+   */
+  k: PropertyKey | Accessor<PropertyKey>
+  /**
+   * Writes the key back into a copy of the parent value.
+   */
+  sv(parentValue: AnyObject, key: PropertyKey, value: unknown): AnyObject
+}
+
+function childCompute(this: ChildNode) {
+  return this.p()?.[$get(this.k)]
+}
+
+function childOper(this: ChildNode, ...value: [NewValue<unknown>]) {
+  if (value.length) {
+    untracked(() => {
+      const parent = this.p()
+      const key = $get(this.k)
+
+      this.p(this.sv(parent, key, nextValue(parent[key], value[0])))
+    })
+  } else {
+    return computedOper.call(this)
+  }
+}
 
 /**
  * Create a writable child signal from a parent signal.
@@ -57,31 +94,22 @@ export function child<
   key: K | Accessor<K>,
   setValue?: (parentValue: P, key: K, value: V) => P
 ) {
-  const getter = computed(() => {
-    const parent = $parent()
+  const writable = isWritable($parent)
 
-    return parent?.[$get(key)]
-  })
-
-  if (!isWritable($parent)) {
-    return getter
-  }
-
-  const setter = (value: NewValue<V>) => untracked(() => {
-    const parent = $parent()
-    const k = $get(key)
-
-    $parent(setValue!(
-      parent,
-      k,
-      nextValue(parent[k], value)
-    ))
-  })
-
-  unsafeMarkWritable(getter)
-
-  return morph(getter, {
-    get: getter,
-    set: setter
-  })
+  // The mode is set in the literal rather than after the fact: the `onSignal`
+  // hook fires from inside `createSignal`, and it is what attaches `set` in
+  // the framework adapters
+  return createSignal(writable ? childOper : computedOper, {
+    value: undefined,
+    subs: undefined,
+    subsTail: undefined,
+    deps: undefined,
+    depsTail: undefined,
+    flags: NoneFlag,
+    modes: writable ? WritableMode : NoneFlag,
+    compute: childCompute,
+    p: $parent,
+    k: key,
+    sv: setValue
+  } as unknown as ChildNode)
 }

--- a/packages/nanoviews/.size-limit.json
+++ b/packages/nanoviews/.size-limit.json
@@ -23,6 +23,6 @@
     "name": "Average usage (Brotli)",
     "path": "dist/index.js",
     "import": "{ fragment, div, form, input, button, label, classList$, if_, for_, value$, $$children, effect }",
-    "limit": "4.05 kB"
+    "limit": "4 kB"
   }
 ]

--- a/packages/store/.size-limit.json
+++ b/packages/store/.size-limit.json
@@ -4,13 +4,13 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "6.1 kB"
+    "limit": "6.15 kB"
   },
   {
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "5.6 kB"
+    "limit": "5.65 kB"
   },
   {
     "name": "Signal (Gzip)",
@@ -23,14 +23,14 @@
     "name": "Signal (Brotli)",
     "path": "dist/index.js",
     "import": "{ signal }",
-    "limit": "1.4 kB"
+    "limit": "1.35 kB"
   },
   {
     "name": "Popular set (Gzip)",
     "gzip": true,
     "path": "dist/index.js",
     "import": "{ signal, record, computed, effect, mountable, onMount }",
-    "limit": "2.45 kB"
+    "limit": "2.4 kB"
   },
   {
     "name": "Popular set (Brotli)",

--- a/packages/store/src/external.ts
+++ b/packages/store/src/external.ts
@@ -1,35 +1,22 @@
 import {
+  type Accessor,
   type WritableSignal,
-  type Morph,
   type NewValue,
-  morph,
+  createSignal,
   signal,
   untracked
 } from 'kida'
+import {
+  type FacadeNode,
+  facadeOper
+} from './facade.js'
 
-export interface ExternalOverrides<T> extends Partial<Omit<Morph<T>, 'source'>> {}
+export interface ExternalOverrides<T> {
+  get?: () => T
+  set?: (value: NewValue<T>) => void
+}
 
 export type ExternalFactory<T> = ($source: WritableSignal<T>, ops: ExternalOverrides<T>) => void
-
-export interface External<T> extends Morph<T> {
-  factory: ExternalFactory<T>
-}
-
-function lazyGetterSetter<T>(this: External<T>, ...value: [NewValue<T>]): T | void {
-  const $source = this.source
-  const ops: ExternalOverrides<T> = {}
-
-  untracked(() => this.factory($source, ops))
-
-  this.get = ops.get ?? $source
-  this.set = ops.set ?? $source
-
-  if (value.length) {
-    this.set(value[0])
-  } else {
-    return this.get()
-  }
-}
 
 /**
  * Create a signal that is controlled by an external source.
@@ -40,9 +27,19 @@ function lazyGetterSetter<T>(this: External<T>, ...value: [NewValue<T>]): T | vo
 export function external<T>(
   factory: ExternalFactory<T>
 ) {
-  return morph(signal<T>(), {
-    get: lazyGetterSetter as () => T,
-    set: lazyGetterSetter,
-    factory
-  }) as WritableSignal<T>
+  const $source = signal<T>() as WritableSignal<T>
+  const node = $source.node as FacadeNode<T>
+
+  // Both faces start as the installer: the factory runs at the first read or
+  // write, over a pair that already defaults to the source, and overrides
+  // whichever side it wants
+  node.get = node.set = ((...value: [NewValue<T>]) => {
+    node.get = node.set = $source
+
+    untracked(() => factory($source, node))
+
+    return value.length ? node.set(value[0]) : node.get()
+  }) as Accessor<T>
+
+  return createSignal(facadeOper, node) as WritableSignal<T>
 }

--- a/packages/store/src/facade.ts
+++ b/packages/store/src/facade.ts
@@ -1,0 +1,23 @@
+import type {
+  Accessor,
+  NewValue,
+  SignalNode
+} from 'kida'
+
+/**
+ * A node wearing a second face: the signal function in front of it reads
+ * through `get` and writes through `set`, while the node itself - and the
+ * signal originally bound to it - stay exactly what they were.
+ */
+export interface FacadeNode<T = unknown> extends SignalNode<T> {
+  get: Accessor<T>
+  set(value: NewValue<T>): void
+}
+
+export function facadeOper<T>(this: FacadeNode<T>, ...value: [NewValue<T>]): T | void {
+  if (value.length) {
+    this.set(value[0])
+  } else {
+    return this.get()
+  }
+}

--- a/packages/store/src/paced.ts
+++ b/packages/store/src/paced.ts
@@ -2,7 +2,7 @@ import {
   type Accessor,
   type NewValue,
   type WritableSignal,
-  morph,
+  createSignal,
   mountable,
   onMount,
   signal,
@@ -10,6 +10,10 @@ import {
   untracked
 } from 'kida'
 import type { RateLimiter } from './types.js'
+import {
+  type FacadeNode,
+  facadeOper
+} from './facade.js'
 
 /**
  * Creates a compute function that returns a rate-limited value from an accessor.
@@ -50,13 +54,16 @@ export function paced<T>(
 ) {
   const $proxy = mountable(signal<T>(untracked($signal)))
   const update = rateLimiter<[NewValue<T>]>($signal)
+  const node = $proxy.node as FacadeNode<T>
 
   onMount($proxy, () => subscribe($signal, $proxy))
 
-  return morph($proxy, {
-    set(value: NewValue<T>) {
-      $proxy(value)
-      update(value)
-    }
-  })
+  node.get = $proxy
+
+  node.set = (value) => {
+    $proxy(value)
+    update(value)
+  }
+
+  return createSignal(facadeOper, node) as WritableSignal<T>
 }

--- a/website/src/content/docs/store/low-level.mdx
+++ b/website/src/content/docs/store/low-level.mdx
@@ -81,40 +81,6 @@ const stop = noMount($data, () => effect(() => {
 }))
 ```
 
-## Signal Morphing
-
-**`morph`** creates a new signal that wraps an existing one with custom get/set behavior. The key feature is that you can dynamically change these behaviors on the fly by modifying `this.get` and `this.set` within the methods themselves.
-
-```ts
-import { signal, morph } from '@nano_kit/store'
-
-const $source = signal(0)
-const $doubled = morph($source, {
-  get() {
-    return this.source() * 2
-  },
-  set(value) {
-    this.source(value / 2)
-  }
-})
-
-$doubled(10)
-console.log($source()) /* 5 */
-console.log($doubled()) /* 10 */
-
-/* You can change behavior on the fly */
-const $dynamic = morph($source, {
-  get() {
-    /* Dynamically change get behavior */
-    if (this.source() > 10) {
-      this.get = () => this.source() * 3
-    }
-
-    return this.source()
-  }
-})
-```
-
 ## Next Values
 
 **`nextValue`** resolves a signal setter value against the previous value. Use it when your low-level API accepts the same `value | updater` shape as writable signals.
@@ -131,18 +97,16 @@ nextValue(prev, value => value + 1) /* 2 */
 **`signalNextValue`** resolves a signal setter value against a writable signal's pending value. This is useful inside custom setters where several writes may happen during the same propagation cycle.
 
 ```ts
-import { signal, morph, signalNextValue } from '@nano_kit/store'
+import { signal, signalNextValue } from '@nano_kit/store'
 
 const $count = signal(0)
-const $positiveCount = morph($count, {
-  set(next) {
-    const value = signalNextValue(this.source, next)
+const setPositive = (next) => {
+  const value = signalNextValue($count, next)
 
-    this.source(Math.max(0, value))
-  }
-})
+  $count(Math.max(0, value))
+}
 
-$positiveCount(count => count + 1)
+setPositive(count => count + 1)
 ```
 
 ## External Signals


### PR DESCRIPTION
`morph` and the `Morph` type are removed. They were exported and documented, but as a low-level escape hatch rather than part of the everyday surface — migration at the bottom, and it is mechanical.

`morph` was never a primitive. It was a work-around for agera's own constructor protocol being private: each of its three call sites already owned a node and only needed to put its own operator in front of it, and `morph` charged every one of them a context object plus a second bound function for the privilege.

## What replaces it

The protocol itself, marked `@private`: `createSignal`, `computedOper`, and the `NoneFlag` / `WritableMode` constants a call site needs to build a node. `createSignal` loses its third parameter — it existed only for `morph` — and binds the operator to the node, so whatever a face needs at call time lives on the node and costs no closure.

The load-bearing observation is that **`compute` is already invoked as a method on the node** (`c.compute(oldValue)` in `updateComputed`, `this.compute()` in `computedOper`). A module-level `childCompute` reading `this.p` and `this.k` is therefore exactly as correct as the closure it replaces, and costs nothing per child.

A writable `child` in kida:

| | before | after |
|---|---|---|
| computed node | 1 | 1 |
| compute closure | 1 | — |
| bound getter | 1 | 1 |
| setter closure | 1 | — |
| morph context object | 1 | — |
| bound morph | 1 | — |
| **total** | **6** | **2** |

Counted with an instrumented build: **one `createSignal` call per writable child instead of two**, and write-back through the child still lands in the parent array.

The two store sites keep a four-line operator of their own over a node carrying `get`/`set` slots — `external` installs its lazy pair there, `paced` its write-through — while the raw signal bound to the same node stays available to internal code. That second face is exactly what the upcoming `for_` row change needs: the reconciler writes the raw signal, user code goes through the write-back.

## Sizes (gzip)

| entry | before | after | Δ |
|---|---:|---:|---:|
| nanoviews Average usage | 4399 | 4356 | **−43** |
| kida Popular set | 2427 | 2388 | **−39** |
| store Popular set | 2430 | 2392 | **−38** |
| nanoviews All publics | 7697 | 7661 | **−36** |
| agera All publics | 2944 | 2921 | **−23** |
| store All publics | 6090 | 6101 | +11 |

`store All` is the only entry that grows, and it is the one that carries both facade sites.

Part of the win is the repo's own duplication effect: kida's node literal is nearly the same text as the literal inside agera's `computed()`, so gzip matches almost all of it.

## Two details worth reviewing

**The writable mode is set in the node literal, not after construction.** The `onSignal` hook fires from inside `createSignal`, and it is what attaches `set` in the Svelte adapter (`packages/svelte/src/core.ts`). Marking the signal writable afterwards would leave writable children without `.set` there.

**`external` hands the node to its factory instead of allocating an `ops` object.** The slots default to the source before the factory runs, and it overrides whichever side it wants — the documented behaviour, with one allocation and one fallback branch less. This is not a new exposure: the node is already reachable as `$source.node` inside the same factory, since `.node` is part of the public signal type.

## Rejected while measuring

- **Inlining the `untracked` barrier in `childOper`** (the trick that paid off in `singleEffect`): +19 gzip on agera All and kida All, because it needs `pushActiveSub`/`popActiveSub` exported — two names in an export list and two in an import list. The barrier is on the write path, which is cold compared to creation. agera grew 19 B without a single line of its own code changing, purely for the exports.
- **A `this`-based installer in `external`** instead of a closure: +9 gzip. A captured variable minifies to one character; `this.x` stays six. State belongs on the node when the alternative is a closure *per instance* — which is `child` — not when it is one closure per cold factory call.
- Codex's `inheritSignal` (child 6→4 allocations) and Fable's `writableComputed` (6→4) both landed above this design; three independent researchers converged on removing `morph` and differed only on the replacement.

## Migration

```ts
// before
const $doubled = morph($source, {
  get() { return this.source() * 2 },
  set(value) { this.source(value / 2) }
})

// after
const node = $source.node

node.get = () => $source() * 2
node.set = value => $source(value / 2)

const $doubled = createSignal(function doubled(...value) {
  if (value.length) {
    this.set(value[0])
  } else {
    return this.get()
  }
}, node)
```

`this.source` becomes the captured signal, and reassigning `this.get` / `this.set` on the fly becomes reassigning those slots. Both faces still share one node, so the reactive graph is unchanged. Documentation for `morph` is removed rather than rewritten: the protocol is `@private`, not a public API.
