### PR TITLE
fix(kida): keep a child write in the caller's context

### DIFF
--- a/packages/agera/src/signal.spec.ts
+++ b/packages/agera/src/signal.spec.ts
@@ -9,6 +9,7 @@ import {
   computed,
   signal,
   effect,
+  untracked,
   isSignal,
   createSignal,
   trigger
@@ -73,6 +74,50 @@ describe('agera', () => {
         'compute',
         'effect'
       ])
+
+      stop()
+    })
+
+    it('should not rerun an effect that writes its own dependency directly', () => {
+      const $tick = signal(0)
+      const $data = signal(0)
+      let runs = 0
+      const stop = effect(() => {
+        $tick()
+
+        const data = $data()
+
+        runs++
+
+        $data(data + 1)
+      })
+
+      $tick(1)
+
+      expect(runs).toBe(2)
+      expect($data()).toBe(2)
+
+      stop()
+    })
+
+    it('should settle an effect that feeds itself instead of running away', () => {
+      const $tick = signal(0)
+      const $data = signal(0)
+      let runs = 0
+      const stop = effect(() => {
+        $tick()
+
+        const data = $data()
+
+        runs++
+
+        untracked(() => $data(data + 1))
+      })
+
+      $tick(1)
+
+      expect(runs).toBe(2)
+      expect($data()).toBe(2)
 
       stop()
     })

--- a/packages/kida/src/internals/child.spec.ts
+++ b/packages/kida/src/internals/child.spec.ts
@@ -6,9 +6,11 @@ import {
 } from 'vitest'
 import {
   signal,
+  mountable,
   effect
 } from 'agera'
 import { assignKey } from './utils.js'
+import { onMount } from './lifecycle.js'
 import { child } from './child.js'
 
 describe('kida', () => {
@@ -151,6 +153,81 @@ describe('kida', () => {
         })
 
         off()
+      })
+
+      it('should not rerun an effect that writes the child it reads', () => {
+        const $map = signal({
+          a: 'clean'
+        })
+        const $a = child($map, 'a', assignKey)
+        let runs = 0
+        // an effect that normalises the child it reads settles: a writer is
+        // never woken by its own write
+        const stop = effect(() => {
+          const value = $a()
+
+          runs++
+
+          if (runs > 10) {
+            throw new Error('runaway')
+          }
+
+          if (value !== value.trim()) {
+            $a(value.trim())
+          }
+        })
+
+        runs = 0
+
+        $map({
+          a: '  dirty  '
+        })
+
+        expect(runs).toBe(1)
+        expect($map()).toEqual({
+          a: 'dirty'
+        })
+
+        stop()
+      })
+
+      it('should not fire mount listeners from inside an effect that writes a child', () => {
+        const log: string[] = []
+        const $map = signal({
+          a: 1
+        })
+        const $a = child($map, 'a', assignKey)
+        const $mountable = mountable(signal('x'))
+
+        onMount($mountable, () => {
+          log.push('mounted')
+        })
+
+        // reaches the mountable signal only once the write has landed, so
+        // the flush the write triggers is what makes it live
+        const stopReader = effect(() => {
+          if ($map().a === 2) {
+            $mountable()
+          }
+        })
+        const stopWriter = effect(() => {
+          log.push('start')
+
+          if ($a() === 1) {
+            $a(2)
+          }
+
+          log.push('end')
+        })
+
+        expect(log).toEqual([
+          'start',
+          'end',
+          'mounted'
+        ])
+
+        stopWriter()
+        stopReader()
       })
     })
   })

--- a/packages/kida/src/internals/child.ts
+++ b/packages/kida/src/internals/child.ts
@@ -39,12 +39,18 @@ function childCompute(this: ChildNode) {
 
 function childOper(this: ChildNode, ...value: [NewValue<unknown>]) {
   if (value.length) {
-    untracked(() => {
-      const parent = this.p()
-      const key = $get(this.k)
+    // Only the reads are untracked: the write itself stays in the caller's
+    // context, so an effect that writes a child it reads is exempted from
+    // its own write instead of being re-run by it
+    let parent!: AnyObject
+    let key!: PropertyKey
 
-      this.p(this.sv(parent, key, nextValue(parent[key], value[0])))
+    untracked(() => {
+      parent = this.p()
+      key = $get(this.k)
     })
+
+    this.p(this.sv(parent, key, nextValue(parent[key], value[0])))
   } else {
     return computedOper.call(this)
   }

--- a/packages/nanoviews/.size-limit.json
+++ b/packages/nanoviews/.size-limit.json
@@ -23,6 +23,6 @@
     "name": "Average usage (Brotli)",
     "path": "dist/index.js",
     "import": "{ fragment, div, form, input, button, label, classList$, if_, for_, value$, $$children, effect }",
-    "limit": "4 kB"
+    "limit": "4.05 kB"
   }
 ]


### PR DESCRIPTION
`childOper` wrapped its whole write path in `untracked` — the reads of the parent and the key, and the write back into the parent along with them. Only the reads need it.

The write does not create dependencies, so untracking it looks free. It is not: `activeSub` is also how the lifecycle queue decides whether the system is quiescent.

```ts
function settle(): void {
  if (
    !draining
    && pending.length
    && (
      activeSub === undefined
      || (activeSub.modes & (ScopeMode | LazyMode)) === ScopeMode
    )
    && !batchDepth
    && !flushDepth
  ) {
```

A write from a subscriber's own body triggers a flush when nothing else holds one open, and `flush` ends by calling `settle`. With the write untracked, `activeSub` is `undefined` at that moment, so `settle` concludes that nobody is running and drains the queue on the spot — and the mount listeners the flush woke fire **inside** the subscriber that wrote, halfway through its body. With the write left in the caller's context, `settle` sees a running subscriber and defers them to the real boundary.

## The gate

```ts
const stopWriter = effect(() => {
  log.push('start')

  if ($a() === 1) {
    $a(2)
  }

  log.push('end')
})
```

where a second effect reaches a `mountable` signal only once that write has landed:

| | log |
|---|---|
| before | `start`, **`mounted`**, `end` |
| after | `start`, `end`, **`mounted`** |

Two gravestones go into `agera`'s signal spec next to it, pinning what a plain signal already guarantees and what the child now stops obscuring: an effect that writes its own dependency is not woken by its own write, whether it writes directly or through `untracked`.

## Size

`nanoviews` gains 4 B gzip / 3 B brotli on the average-usage bundle — two `let` slots the write needs outside the `untracked` block. That is enough to push `Average usage (Brotli)` past its pin (3998 → 4001 B), so the limit moves `4 kB` → `4.05 kB`. Every other pin in the chain stays where it was.
