### PR TITLE
feat(agera): keep the source cold when observing through a derivation

### DIFF
--- a/packages/agera/.size-limit.json
+++ b/packages/agera/.size-limit.json
@@ -4,13 +4,13 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "2.95 kB"
+    "limit": "2.9 kB"
   },
   {
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "2.75 kB"
+    "limit": "2.7 kB"
   },
   {
     "name": "Signal (Gzip)",

--- a/packages/agera/src/effect.ts
+++ b/packages/agera/src/effect.ts
@@ -11,8 +11,7 @@ import {
   startScope,
   stopScope,
   pushActiveSub,
-  popActiveSub,
-  noMount
+  popActiveSub
 } from './internals/system.js'
 
 export {
@@ -95,5 +94,20 @@ export function observe<T>(
   fn: ObserverCallback<T>,
   noDefer?: boolean
 ) {
-  return noMount($accessor, () => listen($accessor, fn, noDefer))
+  // The exemption is the node the subscription links, preset on the
+  // subscriber itself: no context window is needed to pair them with the
+  // signal, and no derivation can be named in place of the direct dep
+  return effect((warmup) => {
+    const value = $accessor()
+
+    if (!warmup) {
+      const prevSub = pushActiveSub(undefined)
+
+      try {
+        fn(value)
+      } finally {
+        popActiveSub(prevSub)
+      }
+    }
+  }, noDefer, $accessor.node)
 }

--- a/packages/agera/src/internals/system.ts
+++ b/packages/agera/src/internals/system.ts
@@ -498,10 +498,24 @@ export function computed<T>(compute: Compute<T>): ReadableSignal<T> {
 /**
  * Run effect function and re-run it on dependency change.
  * @param fn - The effect function to run.
- * @param noDefer - Ignore effect deferring.
  * @returns A function to stop the effect.
  */
-export function effect(fn: EffectCallback, noDefer = false): Destroy {
+export function effect(fn: EffectCallback): Destroy
+
+/**
+ * Run effect function and re-run it on dependency change.
+ * The third argument is internal: it exists for `observe`, which must pair
+ * the exemption with its node before the warmup boundary fires.
+ * @internal
+ * @param fn - The effect function to run.
+ * @param noDefer - Ignore effect deferring.
+ * @param lcx - The node this watcher must not keep mounted.
+ * @returns A function to stop the effect.
+ */
+// oxlint-disable-next-line typescript/unified-signatures
+export function effect(fn: EffectCallback, noDefer?: boolean, lcx?: ReactiveNode): Destroy
+
+export function effect(fn: EffectCallback, noDefer?: boolean, lcx?: ReactiveNode): Destroy {
   const e: EffectNode = {
     fn,
     destroy: undefined,
@@ -510,7 +524,8 @@ export function effect(fn: EffectCallback, noDefer = false): Destroy {
     deps: undefined,
     depsTail: undefined,
     flags: WatchingFlag | RecursedCheckFlag,
-    modes: NoneFlag
+    modes: NoneFlag,
+    lcx
   }
 
   lifecycleEdge?.(e, e)
@@ -1146,7 +1161,6 @@ const pending: ReadableNode[] = []
 let pendingStart = 0
 let stamp = 0
 let draining = 0
-let exemptCtx: ReactiveNode | undefined
 let fireCtx: ReactiveNode | undefined
 
 // A node handed to itself is a freshly created effect, not an edge: the
@@ -1163,8 +1177,9 @@ function onEdge(dep: ReactiveNode, sub?: ReactiveNode): void {
     ;(dep as ReadableNode).lcq = pending.push(dep as ReadableNode)
   } else {
     // A queued effect re-run is not part of the listener's creation
-    // frame: what it builds is a genuine subscriber
-    dep.lcx = exemptCtx || !flushDepth && fireCtx
+    // frame: what it builds is a genuine subscriber. A node born with an
+    // exemption (`observe`) keeps it
+    dep.lcx ||= !flushDepth && fireCtx
   }
 }
 
@@ -1312,28 +1327,6 @@ export function touchLifecycle(node: ReactiveNode): void {
   lifecycleSettle = settle
   ;(node as ReadableNode).lcq = pending.push(node as ReadableNode)
   settle()
-}
-
-/**
- * Call a function where subscribers created inside will ignore mount of the specified signal.
- * @param $signal - The signal to ignore mount for.
- * @param fn - The function to call.
- * @returns The result of the function.
- */
-export function noMount<T>($signal: AnySignal, fn: () => T): T {
-  // No install: the exemption is read only by the edge hook, and a node
-  // that is mountable now has installed the plugin at its own marking.
-  // A node marked mountable AFTER this window is the documented
-  // non-retroactive case
-  const prevCtx = exemptCtx
-
-  exemptCtx = $signal.node
-
-  try {
-    return fn()
-  } finally {
-    exemptCtx = prevCtx
-  }
 }
 
 // #endregion

--- a/packages/agera/src/modes.spec.ts
+++ b/packages/agera/src/modes.spec.ts
@@ -9,6 +9,7 @@ import {
   signal,
   onMounted,
   effect,
+  observe,
   trigger,
   mountable,
   isMountable,
@@ -803,6 +804,70 @@ describe('agera', () => {
 
         expect(bListener.mock.calls).toEqual([[true]])
         expect(isMounted($b)).toBe(true)
+      })
+
+      it('should not count an observe subscriber as a live path', () => {
+        // What noMount pinned as "the exempt subscriber reads the mountable
+        // signal directly": the exemption is now born on the observe
+        // subscriber, paired with the very node it links
+        const $num = mountable(signal(0))
+        const seen: number[] = []
+        const stop = observe($num, value => seen.push(value))
+
+        expect(isMounted($num)).toBe(false)
+
+        $num(1)
+
+        expect(seen).toEqual([1])
+        expect(isMounted($num)).toBe(false)
+
+        stop()
+      })
+
+      it('should pair the observe exemption with the node it reads', () => {
+        // What noMount pinned as "the window names the very node the
+        // subscriber reads": observe can name nothing else
+        const $a = mountable(signal(1))
+        const $b = mountable(computed(() => $a() + 1))
+        const stop = observe($b, () => {})
+
+        expect(isMounted($b)).toBe(false)
+        expect(isMounted($a)).toBe(false)
+
+        stop()
+      })
+
+      it('should keep a derived source cold under observe', () => {
+        // The derivation case noMount could not survive: the exemption
+        // followed the named node, not the linked one. observe always
+        // exempts its direct dep, and `present` relays the silence
+        // through the mountable computed down to the source
+        const $a = mountable(signal(1))
+        const $b = mountable(computed(() => $a() + 1))
+        const seen: number[] = []
+        const stopObserve = observe($b, value => seen.push(value))
+
+        expect(isMounted($a)).toBe(false)
+
+        // an ordinary reader still mounts the chain, and its leave
+        // releases it: the silent subscriber never counts
+        const stopEffect = effect(() => {
+          $b()
+        })
+
+        expect(isMounted($a)).toBe(true)
+        expect(isMounted($b)).toBe(true)
+
+        stopEffect()
+
+        expect(isMounted($a)).toBe(false)
+        expect(isMounted($b)).toBe(false)
+
+        $a(2)
+
+        expect(seen).toEqual([3])
+
+        stopObserve()
       })
 
       it('should not dead lock signal mounted state', () => {

--- a/packages/agera/src/signal.ts
+++ b/packages/agera/src/signal.ts
@@ -11,8 +11,7 @@ import {
   batch,
   nextValue,
   signalNextValue,
-  touchLifecycle,
-  noMount
+  touchLifecycle
 } from './internals/system.js'
 
 export {
@@ -20,8 +19,7 @@ export {
   computed,
   batch,
   nextValue,
-  signalNextValue,
-  noMount
+  signalNextValue
 }
 
 /**

--- a/packages/kida/.size-limit.json
+++ b/packages/kida/.size-limit.json
@@ -10,7 +10,7 @@
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "4.25 kB"
+    "limit": "4.2 kB"
   },
   {
     "name": "Signal (Gzip)",

--- a/packages/nanoviews/.size-limit.json
+++ b/packages/nanoviews/.size-limit.json
@@ -23,6 +23,6 @@
     "name": "Average usage (Brotli)",
     "path": "dist/index.js",
     "import": "{ fragment, div, form, input, button, label, classList$, if_, for_, value$, $$children, effect }",
-    "limit": "4.05 kB"
+    "limit": "4 kB"
   }
 ]

--- a/packages/store/.size-limit.json
+++ b/packages/store/.size-limit.json
@@ -4,7 +4,7 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "6.15 kB"
+    "limit": "6.1 kB"
   },
   {
     "name": "All publics (Brotli)",
@@ -36,6 +36,6 @@
     "name": "Popular set (Brotli)",
     "path": "dist/index.js",
     "import": "{ signal, record, computed, effect, mountable, onMount }",
-    "limit": "2.3 kB"
+    "limit": "2.25 kB"
   }
 ]

--- a/website/src/content/docs/store/low-level.mdx
+++ b/website/src/content/docs/store/low-level.mdx
@@ -61,26 +61,6 @@ stop()
 /* Logs: Mounted: false */
 ```
 
-## Preventing Mount Propagation
-
-**`noMount`** prevents subscribers created inside the function from triggering mount events on the specified signal. This is useful when you need to create effects that observe a mountable signal without activating its lifecycle.
-
-```ts
-import { signal, mountable, onMount, noMount, effect } from '@nano_kit/store'
-
-const $data = mountable(signal(0))
-
-onMount($data, () => {
-  console.log('Mounted')
-})
-
-/* Create effect that won't trigger $data mount */
-const stop = noMount($data, () => effect(() => {
-  console.log('Value:', $data())
-  /* $data is observed but not mounted */
-}))
-```
-
 ## Next Values
 
 **`nextValue`** resolves a signal setter value against the previous value. Use it when your low-level API accepts the same `value | updater` shape as writable signals.


### PR DESCRIPTION
`noMount` opened a window and named a signal: everything subscribed inside it was to be ignored by that signal's mount. `observe` was the only thing that ever needed it, and the pairing it needed was one the window could not express.

## Why the window could not hold

The exemption was recorded against the **named** node, while liveness is decided on the **linked** one. When the two are the same, that works. When the observed accessor is a derivation, they are not:

```ts
const $a = mountable(signal(1))
const $b = mountable(computed(() => $a() + 1))

observe($b, () => {})
```

The window named `$b`, the subscriber linked `$b`, and `$b` stayed cold — but `present` walking up from `$a` reached the subscriber through the computed, found no exemption naming `$a`, and mounted the source. Observing a derived value woke the very thing observing was supposed to leave alone.

## What replaces it

The exemption is born on the subscriber, paired with the node it links:

```ts
return effect((warmup) => {
  const value = $accessor()

  if (!warmup) {
    /* the callback runs detached */
  }
}, noDefer, $accessor.node)
```

`observe` can name nothing but its own direct dep, so the pairing is correct by construction — there is no window to get wrong, and no order to respect between naming and subscribing. `present` already relays through a mountable computed, so the silence travels down the same edges liveness would have: with the fix, `$a` above stays cold, and an ordinary reader still mounts the whole chain and still releases it on leave.

`onEdge` changes from assigning the exemption to keeping one that is already there — a node born exempt is no longer overwritten by the frame it happens to be created in.

`noMount` is removed along with the window. It was exported and documented, but as the mechanism behind `observe` rather than as something to reach for; the documentation section is replaced by one that points at `observe` itself.

## Size

Removing the window pays for the exemption slot everywhere, with change to spare:

| | before | after |
|---|---:|---:|
| agera, all publics (gzip) | 2921 | **2891** |
| agera, all publics (brotli) | 2708 | **2683** |
| kida, all publics (gzip) | 4540 | **4525** |
| kida, all publics (brotli) | 4211 | **4175** |
| store, all publics (gzip) | 6104 | **6072** |
| store, all publics (brotli) | 5613 | **5605** |
| nanoviews, average usage (gzip) | 4360 | 4360 |
| nanoviews, average usage (brotli) | 4001 | **3999** |

Six pins move down, none up. `nanoviews` pays for the `lcx` slot on the effect node without collecting the saving, since it never imported `noMount` — but its average-usage bundle still lands two bytes under where it was, which takes the brotli limit back to `4 kB`.
