### PR TITLE
feat(agera): add `selector` to wake only the keys whose answer changed

### DIFF
--- a/examples/benchmark/nanoviews/src/app.js
+++ b/examples/benchmark/nanoviews/src/app.js
@@ -2,10 +2,9 @@
 import {
   signal,
   record,
+  selector,
   deleteIndex,
   updateArray,
-  computed,
-  clearList,
   assignKey
 } from 'nanoviews/store'
 import {
@@ -104,11 +103,13 @@ function buildData(count = 1000) {
 export function App(ref = {}) {
   const $data = signal([])
   const $selected = signal()
+  const $isSelected = selector($selected)
+
   const add = () => {
     $data(data => [...data, ...buildData(1000)])
   }
   const clear = () => {
-    clearList($data)
+    $data([])
   }
   const partialUpdate = () => {
     updateArray($data, (data) => {
@@ -220,21 +221,24 @@ export function App(ref = {}) {
       tbody()(
         for_($data, item => item.id)(
           ($row, $index) => {
-            $row = record($row)
+            const {
+              $id,
+              $label
+            } = record($row)
 
             return tr({
-              class: computed(() => $selected() === $row.$id() ? 'danger' : '')
+              class: () => $isSelected($id()) ? 'danger' : ''
             })(
               td({ class: 'col-md-1' })(
-                $row.$id
+                $id
               ),
               td({ class: 'col-md-4' })(
                 a({
                   onClick() {
-                    $selected($row.$id())
+                    $selected($id())
                   }
                 })(
-                  $row.$label
+                  $label
                 )
               ),
               td({ class: 'col-md-1' })(

--- a/packages/agera/.size-limit.json
+++ b/packages/agera/.size-limit.json
@@ -4,13 +4,13 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "2.9 kB"
+    "limit": "3.15 kB"
   },
   {
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "2.7 kB"
+    "limit": "2.9 kB"
   },
   {
     "name": "Signal (Gzip)",

--- a/packages/agera/src/internals/system.ts
+++ b/packages/agera/src/internals/system.ts
@@ -1,6 +1,7 @@
 import { isFunction } from '../utils.js'
 import type {
   ReactiveNode,
+  SelectorNode,
   ReadableNode,
   SignalNode,
   ComputedNode,
@@ -12,6 +13,7 @@ import type {
   ReadableSignal,
   EffectCallback,
   Destroy,
+  Accessor,
   Compute,
   NewValue,
   DeferredScope
@@ -891,6 +893,181 @@ function purgeDeps(sub: ReactiveNode) {
 
 // #endregion
 
+// #region Selector
+//
+// A selector is a keyed derivation: one subscriber on the source, one node
+// per key, and a change delivered only to the keys whose answer moved. The
+// key node is the smallest thing the core can deliver to - a value and a
+// `destroy` - and it rides `propagate` and `unlink` untouched: it holds a
+// pushed value, so nothing ever recomputes it.
+// Nothing is attached until a real subscriber asks: the tracker is warmed up
+// by the first tracked call, and the last key to lose its readers stops it,
+// which is what releases the source.
+//
+
+// A key value is derived with the caller detached: the derivation is user
+// code that runs both from a caller's body and from the tracker's own run,
+// and its reads must become a dependency of neither
+function deriveSelector<T, U, R>(fn: ((key: U, value: T) => R) | undefined, key: U, value: T): R {
+  if (!fn) {
+    return (key === value as unknown as U) as R
+  }
+
+  const prevSub = pushActiveSub(undefined)
+
+  try {
+    return fn(key, value)
+  } finally {
+    popActiveSub(prevSub)
+  }
+}
+
+// A key node holds a pushed value, so a change is delivered like a settled
+// signal: `propagate` marks the readers, `shallowPropagate` turns their
+// pending into dirty - without it a reader would check its deps, find a node
+// that never claims to be recomputable, and go back to sleep.
+// `subs` is not empty on any path a consumer can reach: the accessor links
+// the node it has just created, and losing the last reader is what takes it
+// out of the map again. A custom derivation that tears down the last reader
+// of the very key it is asked about, from inside its own call, is the one
+// way out of that - and it is outside the contract, not a case to guard
+function setSelector<R>(node: SelectorNode<R> | undefined, value: R) {
+  if (node !== undefined && node.value !== value) {
+    node.value = value
+
+    const subs = node.subs
+
+    // A custom derivation runs before this: it is user code, and dropping
+    // the last reader of the key it is asked about leaves nobody to notify
+    if (subs !== undefined) {
+      propagate(subs)
+      shallowPropagate(subs)
+    }
+  }
+}
+
+/**
+ * Create a keyed derivation that only notifies readers of changed keys.
+ * @param $source - The source accessor.
+ * @returns A keyed accessor: calling it subscribes the caller to its key.
+ */
+export function selector<T, U extends T = T>($source: Accessor<T>): (key: U) => boolean
+
+/**
+ * Create a keyed derivation that only notifies readers of changed keys.
+ * @param $source - The source accessor.
+ * @param fn - Derives a key value from the key and source value.
+ * @returns A keyed accessor: calling it subscribes the caller to its key.
+ */
+export function selector<T, U = T, R = boolean>(
+  $source: Accessor<T>,
+  fn: (key: U, value: T) => R
+): (key: U) => R
+
+/* @__NO_SIDE_EFFECTS__ */
+export function selector<T, U = T, R = boolean>(
+  $source: Accessor<T>,
+  fn?: (key: U, value: T) => R
+): (key: U) => R {
+  const keys = new Map<U, SelectorNode<R>>()
+  let value: T
+  let tracker: EffectNode | undefined
+  // The single subscriber of the source. Default keys are answered by
+  // identity, so a change moves exactly two of them and the rest are never
+  // visited; a custom derivation has to be asked for every live key
+  const updateSelector = () => {
+    const prevValue = value
+    const nextValue = value = $source()
+
+    if (!fn) {
+      if (prevValue !== nextValue) {
+        setSelector(keys.get(prevValue as unknown as U), false as R)
+        setSelector(keys.get(nextValue as unknown as U), true as R)
+      }
+    } else {
+      for (const [key, node] of keys) {
+        setSelector(node, deriveSelector(fn, key, nextValue))
+      }
+    }
+  }
+
+  return (key) => {
+    // Nothing to attach to: answer from the source and subscribe nobody.
+    // A scope is such a position too, started or not: it never re-runs, so
+    // a key node and a source subscription taken for it could only be paid
+    // for and never used - and the tracker, being an effect, would mount a
+    // mountable source that the same read through a plain signal leaves
+    // alone
+    if (!activeSub || activeSub.modes & (LazyMode | ScopeMode)) {
+      return deriveSelector(fn, key, untracked($source))
+    }
+
+    const flags = tracker?.flags
+
+    // A stopped node is flagged NoneFlag, so one read answers both "is there
+    // a tracker" and "is it still alive" - the tracker is never cleared on
+    // the way out, and a reader created by a listener that runs inside the
+    // tear-down builds a new one instead of reviving the dead one
+    if (!flags) {
+      tracker = {
+        fn: updateSelector,
+        destroy: undefined,
+        subs: undefined,
+        subsTail: undefined,
+        deps: undefined,
+        depsTail: undefined,
+        flags: WatchingFlag | RecursedCheckFlag,
+        // Mountable: the tracker subscribes to the source on behalf of the
+        // keys, which subscribe to it in turn, so presence relays through it
+        // like through a computed instead of stopping at a watcher, and a
+        // key's level change cascades over the same two edges down to the
+        // source. A relay is not a subscriber, so it carries no exemption
+        modes: MountableMode
+      }
+
+      warmupEffect(tracker)
+    } else if (flags & (DirtyFlag | PendingFlag)) {
+      // Asked between a write and its flush: settle first, so the answer is
+      // the one the source already has
+      run(tracker!)
+    }
+
+    let node = keys.get(key)
+
+    if (!node) {
+      node = {
+        value: deriveSelector(fn, key, value),
+        subs: undefined,
+        subsTail: undefined,
+        deps: undefined,
+        depsTail: undefined,
+        flags: MutableFlag,
+        // Mountable so that liveness relays through a key: a computed that
+        // reads one is marked by the same contagion a mountable signal
+        // would give it
+        modes: MountableMode,
+        // Called by `unlink` when the key loses its last reader; `unwatched`
+        // then drops the key's own link to the tracker, and the last key to
+        // go empties the tracker's subs, which stops it and releases the
+        // source - the graph tears the chain down edge by edge
+        destroy: () => keys.delete(key)
+      }
+
+      keys.set(key, node)
+      // The edge that carries both halves of liveness: presence relays
+      // source -> tracker -> keys -> readers, and a key's level change walks
+      // key -> tracker -> source. Made once per key
+      link(tracker!, node, 0)
+    }
+
+    link(node, activeSub, cycle)
+
+    return node.value
+  }
+}
+
+// #endregion
+
 // #region Defer scopes
 //
 // A deferred scope is an ordinary effect scope whose effects are captured
@@ -1194,10 +1371,13 @@ function present(node: ReadableNode): boolean {
       if (
         sub.lcx !== node
         && (
-          // A live effect settles the question; anything else relays only
-          // if it is a mountable computed
-          sub.flags & WatchingFlag
-          || sub.modes & MountableMode && present(sub as ReadableNode)
+          // A relay never counts as a reader, whatever its flags say: the
+          // walk asks its subs instead - a mountable computed's readers, a
+          // tracker's keys. Anything else settles the question iff it is a
+          // live effect
+          sub.modes & MountableMode
+            ? present(sub as ReadableNode)
+            : sub.flags & WatchingFlag
         )
       ) {
         node.lcv = true

--- a/packages/agera/src/internals/types.ts
+++ b/packages/agera/src/internals/types.ts
@@ -133,6 +133,11 @@ export interface SignalNode<T = any> extends WritableNode {
   pendingValue: T
 }
 
+export interface SelectorNode<T = any> extends ReactiveNode {
+  value: T
+  destroy: MaybeDestroy
+}
+
 /**
  * Opaque deferred scope handle.
  * @internal

--- a/packages/agera/src/signal.spec.ts
+++ b/packages/agera/src/signal.spec.ts
@@ -2,17 +2,27 @@ import {
   vi,
   describe,
   it,
-  expect
+  expect,
+  expectTypeOf
 } from 'vitest'
 import {
   type SignalNode,
+  batch,
   computed,
-  signal,
-  effect,
-  untracked,
-  isSignal,
   createSignal,
-  trigger
+  deferScope,
+  effect,
+  effectScope,
+  isMounted,
+  isSignal,
+  mountable,
+  onMounted,
+  selector,
+  signal,
+  startScope,
+  stopScope,
+  trigger,
+  untracked
 } from './index.js'
 
 describe('agera', () => {
@@ -163,6 +173,500 @@ describe('agera', () => {
         src(0)
         c1()
         expect(times).toBe(1)
+      })
+    })
+
+    describe('selector', () => {
+      // One reader per key, stopped together: what a list of rows does to a
+      // selector, without a list of rows
+      const watchKeys = (
+        $selected: (key: number) => boolean,
+        keys: number[],
+        values: boolean[]
+      ) => {
+        const stops = keys.map(key => effect(() => {
+          values.push($selected(key))
+        }))
+
+        return () => stops.forEach(stop => stop())
+      }
+
+      it('should return a plain keyed accessor and answer untracked without subscribing', () => {
+        const source = mountable(signal(1))
+        const mounted = vi.fn()
+        const stopMounted = onMounted(source, mounted)
+        const $isSelected = selector(source)
+
+        expect('node' in $isSelected).toBe(false)
+        expect($isSelected(1)).toBe(true)
+        expect($isSelected(2)).toBe(false)
+        expect(isMounted(source)).toBe(false)
+        expect(mounted).not.toHaveBeenCalled()
+
+        stopMounted()
+      })
+
+      it('should attach on the first tracked key and detach on the last reader', () => {
+        const source = mountable(signal(1))
+        const mounted: boolean[] = []
+        const stopMounted = onMounted(source, value => mounted.push(value))
+        const $isSelected = selector(source)
+        const stopOne = effect(() => {
+          $isSelected(1)
+        })
+        const stopTwo = effect(() => {
+          $isSelected(2)
+        })
+
+        expect(mounted).toEqual([true])
+
+        stopOne()
+        expect(mounted).toEqual([true])
+
+        stopTwo()
+        expect(mounted).toEqual([true, false])
+
+        stopMounted()
+      })
+
+      it('should keep exactly one source link for any number of keys', () => {
+        const source = signal(0)
+        const $isSelected = selector(source)
+        const stops = Array.from(
+          {
+            length: 1000
+          },
+          (_, key) => effect(() => {
+            $isSelected(key)
+          })
+        )
+
+        expect(source.node.subs).toBe(source.node.subsTail)
+        expect(source.node.subs?.nextSub).toBeUndefined()
+
+        stops.forEach(stop => stop())
+
+        expect(source.node.subs).toBeUndefined()
+      })
+
+      it('should only notify keys whose values changed', () => {
+        const source = signal(1)
+        const $isSelected = selector(source)
+        const one = vi.fn()
+        const two = vi.fn()
+        const three = vi.fn()
+        const stops = [
+          effect(() => one($isSelected(1))),
+          effect(() => two($isSelected(2))),
+          effect(() => three($isSelected(3)))
+        ]
+
+        source(2)
+
+        expect(one).toHaveBeenCalledTimes(2)
+        expect(two).toHaveBeenCalledTimes(2)
+        expect(three).toHaveBeenCalledTimes(1)
+
+        stops.forEach(stop => stop())
+      })
+
+      it('should derive custom values and gate unchanged results', () => {
+        const source = signal(1)
+        const $isSelected = selector(source, (key: number, value) => Math.abs(key - value))
+        const zero = vi.fn()
+        const two = vi.fn()
+        const stopZero = effect(() => zero($isSelected(0)))
+        const stopTwo = effect(() => two($isSelected(2)))
+
+        source(3)
+
+        expect(zero).toHaveBeenLastCalledWith(3)
+        expect(zero).toHaveBeenCalledTimes(2)
+        expect(two).toHaveBeenLastCalledWith(1)
+        expect(two).toHaveBeenCalledTimes(1)
+
+        stopZero()
+        stopTwo()
+      })
+
+      it('should propagate through a computed caller', () => {
+        const source = signal(1)
+        const $isSelected = selector(source)
+        const selectedOne = computed(() => $isSelected(1))
+        const values: boolean[] = []
+        const stop = effect(() => {
+          values.push(selectedOne())
+        })
+
+        source(2)
+        source(3)
+        source(1)
+
+        expect(values).toEqual([true, false, true])
+
+        stop()
+      })
+
+      it('should support two callers of the same key', () => {
+        const source = signal(1)
+        const $isSelected = selector(source)
+        const first = vi.fn()
+        const second = vi.fn()
+        const stopFirst = effect(() => first($isSelected(1)))
+        const stopSecond = effect(() => second($isSelected(1)))
+
+        stopFirst()
+        source(2)
+
+        expect(first).toHaveBeenCalledTimes(1)
+        expect(second).toHaveBeenCalledTimes(2)
+
+        stopSecond()
+      })
+
+      it('should release churned keys and recreate a $isSelected key correctly', () => {
+        const source = mountable(signal(2))
+        const states: boolean[] = []
+        const $isSelected = selector(source)
+        const stop = watchKeys($isSelected, [1, 2, 3], states)
+
+        expect(states).toEqual([false, true, false])
+
+        stop()
+        expect(isMounted(source)).toBe(false)
+
+        const recreated: boolean[] = []
+        const stopRecreated = watchKeys($isSelected, [2, 4], recreated)
+
+        expect(recreated).toEqual([true, false])
+
+        stopRecreated()
+      })
+
+      it('should not retain destroyed keys across list replacement', () => {
+        const source = signal(0)
+        const derive = vi.fn((key: number, value: number) => key === value)
+        const $isSelected = selector(source, derive)
+        const first = Array.from(
+          {
+            length: 20
+          },
+          (_, key) => key
+        )
+        const second = Array.from(
+          {
+            length: 20
+          },
+          (_, key) => key + 20
+        )
+        const stopFirst = watchKeys($isSelected, first, [])
+
+        stopFirst()
+
+        const stopSecond = watchKeys($isSelected, second, [])
+
+        derive.mockClear()
+        source(1)
+
+        expect(derive).toHaveBeenCalledTimes(20)
+
+        stopSecond()
+      })
+
+      it('should move a caller between keys and release the old key', () => {
+        const source = signal(1)
+        const key = signal(1)
+        const $isSelected = selector(source)
+        const values: boolean[] = []
+        const stop = effect(() => {
+          values.push($isSelected(key()))
+        })
+
+        key(2)
+        source(2)
+        source(1)
+
+        expect(values).toEqual([true, false, true, false])
+
+        stop()
+      })
+
+      it('should answer a $isSelected key first requested inside a batch', () => {
+        const source = signal(1)
+        const $isSelected = selector(source)
+        const first: boolean[] = []
+        const stopFirst = effect(() => {
+          first.push($isSelected(1))
+        })
+        const second: boolean[] = []
+        let stopSecond: (() => void) | undefined
+
+        batch(() => {
+          source(2)
+          stopSecond = effect(() => {
+            second.push($isSelected(2))
+          })
+
+          // asked between the write and its flush: the answer is the one the
+          // source already has, and it is answered once
+          expect(second).toEqual([true])
+        })
+
+        expect(first).toEqual([true, false])
+        expect(second).toEqual([true])
+
+        stopFirst()
+        stopSecond!()
+      })
+
+      it('should not notify keys when the source settles on the same value', () => {
+        const source = signal(1)
+        const $isSelected = selector(source)
+        const seen: boolean[] = []
+        const stop = effect(() => {
+          seen.push($isSelected(1))
+        })
+
+        trigger(() => source())
+
+        expect(seen).toEqual([true])
+
+        stop()
+      })
+
+      it('should not mount the source from a reader a mount listener created', () => {
+        const source = mountable(signal(1))
+        const $isSelected = selector(source)
+        let inside: (() => void) | undefined
+
+        // the exemption is per subscriber and names the node that subscriber
+        // reads: a reader of a key is not exempt from the source behind it,
+        // exactly as a reader of a computed is not. So it does keep the
+        // source mounted - and a selector says the same thing a computed
+        // over the same signal says
+        onMounted(source, (mounted) => {
+          if (mounted) {
+            inside = effect(() => {
+              $isSelected(1)
+            })
+          }
+        })
+
+        const stop = effect(() => {
+          $isSelected(2)
+        })
+
+        expect(isMounted(source)).toBe(true)
+
+        stop()
+
+        expect(isMounted(source)).toBe(true)
+
+        inside?.()
+
+        expect(isMounted(source)).toBe(false)
+      })
+
+      it('should survive a derivation that drops the last reader of its key', () => {
+        const source = signal(1)
+        const seen: boolean[] = []
+        // oxlint-disable-next-line prefer-const
+        let stopOwn: (() => void) | undefined
+        // user code runs before the key is notified, and it is allowed to
+        // take the very reader the notification was meant for
+        const $isSelected = selector(source, (key: number, value) => {
+          if (key === 1 && value === 9) {
+            stopOwn!()
+          }
+
+          return key === value
+        })
+
+        stopOwn = effect(() => {
+          $isSelected(1)
+        })
+
+        const stop = effect(() => {
+          seen.push($isSelected(2))
+        })
+
+        source(9)
+
+        expect(seen).toEqual([false])
+
+        source(2)
+
+        expect(seen).toEqual([false, true])
+
+        stop()
+      })
+
+      it('should not attach for a read in a scope body', () => {
+        const source = mountable(signal(1))
+        const $isSelected = selector(source)
+        // a scope never re-runs, so a subscription taken for it could only
+        // be paid for and never used - and it must not mount the source,
+        // just as a plain signal read from the same place does not
+        const stopScope = effectScope(() => {
+          expect($isSelected(1)).toBe(true)
+          expect($isSelected(2)).toBe(false)
+        })
+
+        expect(isMounted(source)).toBe(false)
+        expect(source.node.subs).toBeUndefined()
+
+        stopScope()
+      })
+
+      it('should reject key and result types the runtime cannot honour', () => {
+        const $num = signal(1)
+
+        // @ts-expect-error a result type without a derivation: the runtime answers booleans
+        selector<number, number, string>($num)
+        // @ts-expect-error a key type unrelated to the source: nothing can ever match
+        selector<number, string>($num)
+
+        const $isSelected = selector($num)
+        const $derived = selector($num, (key: number, value) => `${key}:${value}`)
+
+        expectTypeOf($isSelected).toEqualTypeOf<(key: number) => boolean>()
+        expectTypeOf($derived).toEqualTypeOf<(key: number) => string>()
+        expect($isSelected(1)).toBe(true)
+      })
+
+      it('should infer the key from the source in a derivation', () => {
+        const $num = signal(1)
+        const $isSelected = selector($num, (key, value) => key === value)
+
+        expectTypeOf($isSelected).toEqualTypeOf<(key: number) => boolean>()
+        expect($isSelected(1)).toBe(true)
+      })
+
+      it('should allow a key narrower than the source', () => {
+        const $selected = signal<number | undefined>(undefined)
+        const $isSelected = selector<number | undefined, number>($selected)
+
+        expect($isSelected(1)).toBe(false)
+      })
+
+      it('should allow a caller to ask for a key while the selector is updating', () => {
+        const source = signal(1)
+        let stopNested: (() => void) | undefined
+        let nested: boolean | undefined
+        const $isSelected = selector(source, (key: number, value) => {
+          if (key === 1 && value === 2 && stopNested === undefined) {
+            stopNested = effect(() => {
+              nested = $isSelected(2)
+            })
+          }
+
+          return key === value
+        })
+        const outer: boolean[] = []
+        const stopOuter = effect(() => {
+          outer.push($isSelected(1))
+        })
+
+        source(2)
+
+        expect(outer).toEqual([true, false])
+        expect(nested).toBe(true)
+
+        stopOuter()
+        stopNested!()
+      })
+
+      it('should work in nested effects without attaching the tracker to the caller', () => {
+        const source = mountable(signal(1))
+        const outer = signal(true)
+        const $isSelected = selector(source)
+        let stopInner: (() => void) | undefined
+        const stopOuter = effect(() => {
+          outer()
+          stopInner?.()
+          stopInner = effect(() => {
+            $isSelected(1)
+          })
+        })
+
+        outer(false)
+        expect(isMounted(source)).toBe(true)
+
+        stopOuter()
+        expect(isMounted(source)).toBe(false)
+
+        stopInner!()
+        expect(isMounted(source)).toBe(false)
+      })
+
+      it('should attach and detach with a deferred scope only while it is started', () => {
+        const source = mountable(signal(1))
+        const $isSelected = selector(source)
+        const values: boolean[] = []
+        const scope = deferScope(() => {
+          effect(() => {
+            values.push($isSelected(1))
+          })
+        })
+
+        expect(values).toEqual([])
+        expect(isMounted(source)).toBe(false)
+
+        startScope(scope)
+        expect(values).toEqual([true])
+        expect(isMounted(source)).toBe(true)
+
+        stopScope(scope)
+        expect(isMounted(source)).toBe(false)
+      })
+
+      it('should not attach for a direct read in a deferred scope body', () => {
+        const source = mountable(signal(1))
+        const $isSelected = selector(source)
+        const scope = deferScope(() => {
+          $isSelected(1)
+        })
+
+        expect(isMounted(source)).toBe(false)
+        expect(source.node.subs).toBeUndefined()
+
+        startScope(scope)
+        expect(isMounted(source)).toBe(false)
+
+        stopScope(scope)
+      })
+
+      it('should not track custom derivation reads in a caller', () => {
+        const source = signal(1)
+        const other = signal('a')
+        const $isSelected = selector(source, (key: number, value) => `${key === value}:${other()}`)
+        const values: string[] = []
+        const stop = effect(() => {
+          values.push($isSelected(1))
+        })
+
+        other('b')
+        expect(values).toEqual(['true:a'])
+
+        source(2)
+        expect(values).toEqual(['true:a', 'false:b'])
+
+        stop()
+      })
+
+      it('should answer untracked from the current source during a batch', () => {
+        const source = signal(1)
+        const $isSelected = selector(source)
+        const stop = effect(() => {
+          $isSelected(1)
+        })
+
+        batch(() => {
+          source(2)
+          expect(untracked(() => $isSelected(2))).toBe(true)
+        })
+
+        stop()
       })
     })
 

--- a/packages/agera/src/signal.ts
+++ b/packages/agera/src/signal.ts
@@ -8,6 +8,7 @@ import type {
 import {
   signal,
   computed,
+  selector,
   batch,
   nextValue,
   signalNextValue,
@@ -17,6 +18,7 @@ import {
 export {
   signal,
   computed,
+  selector,
   batch,
   nextValue,
   signalNextValue

--- a/packages/kida/.size-limit.json
+++ b/packages/kida/.size-limit.json
@@ -4,13 +4,13 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "4.55 kB"
+    "limit": "4.8 kB"
   },
   {
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "4.2 kB"
+    "limit": "4.4 kB"
   },
   {
     "name": "Signal (Gzip)",

--- a/packages/nanoviews/.size-limit.json
+++ b/packages/nanoviews/.size-limit.json
@@ -23,6 +23,6 @@
     "name": "Average usage (Brotli)",
     "path": "dist/index.js",
     "import": "{ fragment, div, form, input, button, label, classList$, if_, for_, value$, $$children, effect }",
-    "limit": "4 kB"
+    "limit": "4.05 kB"
   }
 ]

--- a/packages/store/.size-limit.json
+++ b/packages/store/.size-limit.json
@@ -4,13 +4,13 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "6.1 kB"
+    "limit": "6.35 kB"
   },
   {
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "5.65 kB"
+    "limit": "5.8 kB"
   },
   {
     "name": "Signal (Gzip)",

--- a/website/src/content/docs/store/core-concepts.mdx
+++ b/website/src/content/docs/store/core-concepts.mdx
@@ -221,6 +221,40 @@ const $count = signal(1)
 const $total = computed((sum = 0) => sum + $count())
 ```
 
+### Using `selector`
+
+When many things ask the same question about one value — which row is selected, which tab is open, which item is being dragged — a `computed` per asker subscribes them all to that value, and every change wakes all of them so that all but one can conclude that nothing changed. `selector` inverts that: the source gets one subscriber, and a change reaches only the keys whose answer actually moved.
+
+```ts
+import { signal, selector, effect } from '@nano_kit/store'
+
+const $selected = signal<number>()
+const $isSelected = selector($selected)
+
+/* Each row asks about its own key and is woken only for its own key */
+const stop = effect(() => {
+  console.log('row 2 selected:', $isSelected(2))
+})
+
+$selected(1) /* row 2 is not woken */
+$selected(2) /* row 2 is woken, row 1 is woken to unselect */
+```
+
+`selector` returns a plain function, not a signal: it has no value of its own, and calling it inside a tracked context subscribes the caller to that key alone. Called outside one, it just answers.
+
+By default a key is selected when it is strictly equal to the source value. A second argument replaces that rule with any derivation of `(key, value)`:
+
+```ts
+const $range = signal(0)
+const $distance = selector($range, (key: number, value) => Math.abs(key - value))
+
+effect(() => {
+  console.log('distance from 5:', $distance(5))
+})
+```
+
+A custom derivation is asked for every live key on each change, while the default comparison moves exactly two — so keep the default where it fits.
+
 ## Mountable Stores
 
 Wrap a signal (or computed) with `mountable` to control its lifecycle using the `onMount` hook. This allows you to execute side effects—like subscribing to external data sources or fetching data—when the signal becomes active, and clean up resources when it's no longer in use. This pattern moves business logic from components to stores, making it framework-agnostic and easier to test.


### PR DESCRIPTION
When many things ask the same question about one value — which row is selected, which tab is open, which item is dragged — a `computed` per asker subscribes them all to that value. Every change then wakes all of them so that all but one can conclude that nothing changed.

`selector` inverts it: the source gets **one** subscriber, and a change reaches only the keys whose answer actually moved.

```ts
const $selected = signal<number>()
const $isSelected = selector($selected)

/* each row asks about its own key and is woken only for its own key */
effect(() => {
  console.log('row 2 selected:', $isSelected(2))
})

$selected(1) /* row 2 is not woken */
$selected(2) /* row 2 is woken, row 1 is woken to unselect */
```

## Shape

One subscriber on the source, one node per key, and the change pushed to the keys that moved. The key node is the smallest thing the core can deliver to — a value and a `destroy` — and it rides `propagate` and `unlink` untouched: it holds a pushed value, so nothing ever recomputes it.

Nothing is attached until a real subscriber asks. The tracker is warmed up by the first tracked call, and the last key to lose its readers stops it, which is what releases the source. A key that loses its last reader deletes itself from the map through `destroy`, so churn does not leak.

The default rule answers `key === value`, which moves exactly two keys per change and never visits the rest. A second argument replaces it with any derivation of `(key, value)`:

```ts
const $distance = selector($range, (key: number, value) => Math.abs(key - value))
```

A custom derivation has to be asked for every live key on each change — so the default stays the one to reach for.

The returned function is not a signal. It has no value of its own, and calling it inside a tracked context subscribes the caller to that key alone; called outside one, it just answers. User derivations run with the caller detached, so their reads become nobody's dependency.

## Liveness

A key relays presence like a mountable computed does, in both directions: `present` walks source → tracker → keys → readers, and a key's level change walks back down the same two edges. So a `mountable` source behaves under a selector exactly as it behaves under a `computed` — cold under a scope read, mounted through a live key, and released when that key's last reader leaves. The tracker itself is a relay, not a reader: it is an effect, and `present` had to learn to ask a relay's subscribers instead of stopping at its `WatchingFlag`.

## Cost

**+240 B gzip** in agera. Three models were set on the region at maximum effort to squeeze it; two of them rebuilt the size-limit pipeline and measured every variant. The best no-regression stack came to −15 B and the most aggressive to −28 B, none of which moves the pin (anything above 3100 B pins at `3.15 kB`), so the region ships as written. What that round did establish: the node literals are nearly free — the tracker's is 87 minified bytes but **5 B gzipped**, because it is a byte-identical run with `effect()`'s — and every attempt to shorten them, share them through a factory or drop a field came back bigger. The only real lever is a computed-per-key redesign at −164 B, and it costs the whole point of the primitive: O(n) propagation per change, leaked keys, and a scope read that mounts the source.

Pins move up in agera, kida and store; `nanoviews` pays 2 B of brotli for the `present` relay branch, which sits on the hot path.

## Benchmark

`examples/benchmark/nanoviews` switches its row class from a per-row `computed` to `selector`, which is what the js-framework-benchmark app does too. On the full six-framework run that took `select 1k` from **14.9 ms to 9.8 ms** — tied for first place with vue-vapor, where it had been 1.5× off the best.
