### PR TITLE
fix(nanoviews): render the branch brought back by a write to the condition

### DIFF
--- a/packages/nanoviews/src/flow/if.spec.ts
+++ b/packages/nanoviews/src/flow/if.spec.ts
@@ -9,8 +9,13 @@ import { render } from '@nanoviews/testing-library'
 import {
   type WritableSignal,
   type ReadableSignal,
-  signal
+  signal,
+  effect
 } from 'kida'
+import {
+  b,
+  i
+} from '../elements/elements.js'
 import * as Stories from './if.stories.js'
 import { if_ } from './if.js'
 
@@ -53,6 +58,100 @@ describe('nanoviews', () => {
         value(false)
 
         expect(container.innerHTML).toBe('<div></div>')
+      })
+
+      it('should render a write to the condition made by the branch it selected', () => {
+        const $open = signal(false)
+        const $allowed = signal(false)
+        const $text = signal('closed')
+        const { container } = render(() => if_($open)(
+          () => {
+            // the branch refuses to be shown, so the write reaches the
+            // condition from an effect the swap itself started
+            effect(() => {
+              if (!$allowed()) {
+                $open(false)
+              }
+            })
+
+            return b()('open')
+          },
+          () => i()($text)
+        ))
+
+        $open(true)
+
+        expect(container.innerHTML).toBe('<div><i>closed</i></div>')
+
+        // the branch the write brought back is live, not merely rendered
+        $text('shut')
+
+        expect(container.innerHTML).toBe('<div><i>shut</i></div>')
+      })
+
+      it('should render a write to the condition made while the branch renders', () => {
+        const $open = signal(false)
+        const $tick = signal(0)
+        const runs: number[] = []
+        const { container } = render(() => if_($open)(
+          () => {
+            $open(false)
+
+            return b()('open')
+          },
+          () => {
+            // an effect of the branch the write brought back: unlike a
+            // binding it runs only if that branch was started
+            effect(() => {
+              runs.push($tick())
+            })
+
+            return i()('closed')
+          }
+        ))
+
+        $open(true)
+
+        expect(container.innerHTML).toBe('<div><i>closed</i></div>')
+        expect(runs).toEqual([0, 0])
+
+        $tick(1)
+
+        expect(runs).toEqual([0, 0, 1])
+      })
+
+      it('should start the branch brought up by a write made on mount', () => {
+        const $open = signal(true)
+        const $allowed = signal(false)
+        const $tick = signal(0)
+        const runs: number[] = []
+        const { container } = render(() => if_($open)(
+          () => {
+            effect(() => {
+              if (!$allowed()) {
+                $open(false)
+              }
+            })
+
+            return b()('open')
+          },
+          () => {
+            // an effect of the branch the mount-time write brought up:
+            // unlike a binding it runs only if that branch was started
+            effect(() => {
+              runs.push($tick())
+            })
+
+            return i()('closed')
+          }
+        ))
+
+        expect(container.innerHTML).toBe('<div><i>closed</i></div>')
+        expect(runs).toEqual([0])
+
+        $tick(1)
+
+        expect(runs).toEqual([0, 1])
       })
 
       it('should keep signal type in branches', () => {

--- a/packages/nanoviews/src/internals/effects.ts
+++ b/packages/nanoviews/src/internals/effects.ts
@@ -13,8 +13,9 @@ import type { EffectScopeSwapperCallback } from './types/index.js'
 export function deferScopeBindContext(context = getContext()) {
   const factory = boundDeferScope()
 
-  // Render under the injection context, start strictly outside of it
-  return (fn: () => void, replace?: DeferredScope): DeferredScope => startScope(unsafeRun(context, factory, fn, replace))
+  // Render under the injection context; starting the scope is not the
+  // renderer's move
+  return (fn: () => void, replace?: DeferredScope): DeferredScope => unsafeRun(context, factory, fn, replace)
 }
 
 export function effectScopeSwapper<T>(
@@ -23,9 +24,14 @@ export function effectScopeSwapper<T>(
 ) {
   let prev: DeferredScope | undefined
 
+  // The swap starts what it returns. Before the mount walk the scope's
+  // anchor is still lazy and the start is a no-op, so the walk keeps the
+  // block's position; after it the swapped-in content comes up on the
+  // swap's own stack, so a swap correcting a write made mid-render leaves
+  // no scope behind that is rendered but never started
   effect(() => {
     const value = $signal()
 
-    prev = untracked(() => callback(prev, value))
+    prev = untracked(() => startScope(callback(prev, value)))
   }, true)
 }

--- a/packages/nanoviews/src/internals/flow/decide.ts
+++ b/packages/nanoviews/src/internals/flow/decide.ts
@@ -2,6 +2,7 @@ import {
   type Accessor,
   type ValueOrAccessor,
   type DeferredScope,
+  effect,
   isAccessor
 } from 'kida'
 import type { Child } from '../types/index.js'
@@ -38,6 +39,12 @@ export function reactiveDecide<T>(
 
     insertChildBeforeAnchor(decider(condition), end)
   }, destroyPrev))
+
+  // The echo: a branch that writes the condition back does it from inside
+  // the running swapper, which cannot be re-queued by its own propagation.
+  // This second subscriber is idle at that moment, so its read settles the
+  // condition and re-queues the parked swapper for the corrective swap
+  effect(() => void $condition(), true)
 
   return fragment
 }


### PR DESCRIPTION
A branch is allowed to disagree with the condition that selected it. A form that refuses to open until something is allowed, a row that normalises the value it was handed — the write goes back into the very signal the block swaps on, and the block has to end up showing the branch the write asks for.

It did not. The block showed the contradicted branch, and worse: the corrective branch was **rendered but never started**, so its DOM was in place while its effects never ran and never would.

```ts
if_($open)(
  () => {
    /* the branch refuses to be shown */
    effect(() => {
      if (!$allowed()) {
        $open(false)
      }
    })

    return b()('open')
  },
  () => i()($text)
)

$open(true)
```

Before: `<b>open</b>`. The write to `$open` landed while the swapper that reads `$open` was running, and a running effect cannot be re-queued by its own propagation, so the swap that would undo it never happened.

## Two halves

**Starting a scope is not the renderer's move.** `deferScopeBindContext` rendered the new content *and* started it. Now it only renders, and the swap starts what its callback returns:

```diff
-    prev = untracked(() => callback(prev, value))
+    prev = untracked(() => startScope(callback(prev, value)))
```

Before the mount walk the scope's anchor is still lazy and the start is a no-op, so the walk keeps the block's position among its siblings exactly as before. After it, the swapped-in content comes up on the swap's own stack — which is what leaves no scope behind that is rendered but never started.

**The echo.** That alone settles a write made from the branch's render body, but not one made from a binding the branch started: at that moment the swapper is parked, and nothing re-reads the condition. `decide` now carries a second subscriber that does nothing but read it:

```ts
effect(() => void $condition(), true)
```

It is idle when the branch writes, so it is free to be notified, and its read settles the condition and re-queues the parked swapper for the corrective swap.

## Tests

Three in `if.spec.ts`, and they check the branch is **live**, not merely rendered — each asserts an effect of the brought-back branch, which only runs if that branch was started:

- a write from a binding the selected branch started (fails before this change),
- a write made while the branch renders (fails before this change),
- a write made on mount, which brings a branch up before the block was ever shown.

`for_` goes through the same swapper and its whole suite is unchanged; no size pin moves anywhere in the chain.
