### PR TITLE
fix(nanoviews): show the `for_` placeholder when there is no array at all

### DIFF
--- a/packages/nanoviews/src/flow/for.spec.ts
+++ b/packages/nanoviews/src/flow/for.spec.ts
@@ -1002,6 +1002,36 @@ describe('nanoviews', () => {
         expect(runs).toEqual([0])
       })
 
+      it('should render the placeholder for an absent array', () => {
+        const items = signal<Player[] | undefined>(undefined)
+        const { container } = render(() => ul()(
+          for_(items, trackById)(
+            item => li()(record(item).$name),
+            () => li()('nobody')
+          )
+        ))
+
+        expect(container.innerHTML).toBe('<div><ul><li>nobody</li></ul></div>')
+
+        items([
+          {
+            id: 1,
+            name: 'Yatoro'
+          }
+        ])
+
+        expect(container.innerHTML).toBe('<div><ul><li>Yatoro</li></ul></div>')
+
+        // no array is the same emptiness as an empty one
+        items(undefined)
+
+        expect(container.innerHTML).toBe('<div><ul><li>nobody</li></ul></div>')
+
+        items([])
+
+        expect(container.innerHTML).toBe('<div><ul><li>nobody</li></ul></div>')
+      })
+
       describe('fuzz', () => {
         // A named test pins a shape someone thought of; these walk sequences
         // nobody did. Both invariants are checked after every step: the rows

--- a/packages/nanoviews/src/flow/for.ts
+++ b/packages/nanoviews/src/flow/for.ts
@@ -2,6 +2,7 @@ import {
   type Accessor,
   type ReadableSignal,
   type WritableSignal,
+  type EmptyValue,
   isAccessor
 } from 'kida'
 import {
@@ -51,8 +52,12 @@ type StaticEach<T> = (
 
 type UnknownTrack = (item: unknown, index: number) => unknown
 
+// A signal is invariant, so the nullable array is a separate arm rather than
+// a widening of the first: `WritableSignal<T[]>` does not fit
+// `WritableSignal<T[] | EmptyValue>`, and widening would take the rows of
+// every existing caller down to read-only
 export function for_<T>(
-  $items: WritableSignal<T[]>,
+  $items: WritableSignal<T[]> | WritableSignal<T[] | EmptyValue>,
   track?: (item: T, index: number) => unknown
 ): (
   each_: WritableEach<T>,
@@ -60,7 +65,7 @@ export function for_<T>(
 ) => Child
 
 export function for_<T>(
-  $items: Accessor<T[]>,
+  $items: Accessor<T[] | EmptyValue>,
   track?: (item: T, index: number) => unknown
 ): (
   each_: ReadableEach<T>,
@@ -68,7 +73,7 @@ export function for_<T>(
 ) => Child
 
 export function for_<T>(
-  $items: T[]
+  $items: T[] | EmptyValue
 ): (
   each_: StaticEach<T>,
   else_?: () => Child
@@ -81,7 +86,7 @@ export function for_<T>(
  * @returns Function to receive each_ and else_ functions
  */
 export function for_(
-  $items: unknown[] | Accessor<unknown[]>,
+  $items: unknown[] | EmptyValue | Accessor<unknown[] | EmptyValue>,
   track?: UnknownTrack
 ) {
   if (isAccessor($items)) {

--- a/packages/nanoviews/src/internals/flow/loop.ts
+++ b/packages/nanoviews/src/internals/flow/loop.ts
@@ -19,7 +19,10 @@ import {
   nextValue,
   assignIndex
 } from 'kida'
-import type { Child } from '../types/index.js'
+import type {
+  Child,
+  EmptyValue
+} from '../types/index.js'
 import {
   deferScopeBindContext,
   effectScopeSwapper
@@ -341,7 +344,7 @@ function reconcile(
 }
 
 export function loop(
-  $items: Accessor<unknown[]>,
+  $items: Accessor<unknown[] | EmptyValue>,
   each_: AnyEach,
   else_?: () => Child,
   track: UnknownTrack = (_, i) => i
@@ -389,9 +392,11 @@ export function loop(
 
   effectScopeSwapper($items, (
     destroyPrev: DeferredScope | undefined,
-    items: unknown[]
+    items: unknown[] | EmptyValue
   ) => {
-    const itemsCount = items.length
+    // No array at all is the same emptiness as an empty one: the rows go and
+    // the placeholder comes, and nothing below ever reaches into it
+    const itemsCount = items?.length
 
     if (itemsCount && destroyPrev !== undefined && !isPlaceholder) {
       // [...m] -> [...n]
@@ -405,7 +410,7 @@ export function loop(
         reconcile,
         itemsList,
         blocksMap,
-        $items,
+        $items as Accessor<unknown[]>,
         each_,
         track,
         end,
@@ -438,7 +443,7 @@ export function loop(
           reconcile(
             itemsList,
             blocksMap,
-            $items,
+            $items as Accessor<unknown[]>,
             each_,
             track,
             end,

--- a/todo.txt
+++ b/todo.txt
@@ -44,13 +44,11 @@
 - hooks/effects naming convention
 
 - error boundaries: cleanup half-created scope on render throw (stopScope in catch) - rows/content are not parent-linked, teardown must be explicit
-- for loop array or empty check for else
 - for_ duplicate track keys: unsupported by design, must keep failing loudly - the crash lands a step away from the cause, so it needs a clear throw at the point of detection
 - rework return slot$ to look like element/component? fn.prop is faster than {f,p}
 - util to transform static props to signal props?
 - typed effectattrs <T>
 - additional arg for record in for$? as$
-- controls addEventListener to events system
 - static index for untracked loop?
 
 for_($items)(


### PR DESCRIPTION
`for_` over a signal that holds `null` or `undefined` threw:

```
TypeError: Cannot read properties of null (reading 'length')
```

Both on the first render and on a change from a list to nothing. The static form already did the right thing — it happens to be written `$items?.length ? … : else_?.()` — so the two forms disagreed about the same input.

No array is the same emptiness as an empty one, so the fix is to say that:

```diff
-    const itemsCount = items.length
+    // No array at all is the same emptiness as an empty one: the rows go and
+    // the placeholder comes, and nothing below ever reaches into it
+    const itemsCount = items?.length
```

Nothing else in the loop needed a guard. The array is only touched further down when `itemsCount` is truthy, and TypeScript narrows it from that alone — two attempts to add a `!` were rejected by the linter as unnecessary assertions.

## The overload arm

The interesting half is the types. Widening the writable overload from `WritableSignal<T[]>` to `WritableSignal<T[] | EmptyValue>` looks like the obvious move and is wrong: a signal is invariant, so `WritableSignal<Player[]>` does not fit the widened parameter, every existing caller falls through to the *readable* overload, and its rows silently become read-only. Four existing tests failed with `Expected 0 arguments, but got 1` on a row write.

So the nullable array is a separate arm of the same signature:

```ts
// A signal is invariant, so the nullable array is a separate arm rather than
// a widening of the first: `WritableSignal<T[]>` does not fit
// `WritableSignal<T[] | EmptyValue>`, and widening would take the rows of
// every existing caller down to read-only
export function for_<T>(
  $items: WritableSignal<T[]> | WritableSignal<T[] | EmptyValue>,
  track?: (item: T, index: number) => unknown
): (
  each_: WritableEach<T>,
  else_?: () => Child
) => Child
```

The readable and static overloads widen normally.

## Tests

One test walking all four transitions: absent on first render shows the placeholder, absent → list shows the row, list → absent brings the placeholder back, and absent → `[]` leaves it alone rather than tearing it down and building it again. 110 pass.

Size: +1 B gzip on all publics, average usage unchanged, every pin stays where it is.
