### PR TITLE
feat(nanoviews): add `as_` to hand a row through a transform

### DIFF
--- a/packages/nanoviews/.size-limit.json
+++ b/packages/nanoviews/.size-limit.json
@@ -10,7 +10,7 @@
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "6.6 kB"
+    "limit": "6.65 kB"
   },
   {
     "name": "Average usage (Gzip)",

--- a/packages/nanoviews/src/flow/for.spec.ts
+++ b/packages/nanoviews/src/flow/for.spec.ts
@@ -25,6 +25,7 @@ import {
 import { fragment } from '../elements/fragment.js'
 import {
   trackById,
+  as_,
   for_
 } from './for.js'
 import * as Stories from './for.stories.js'
@@ -1030,6 +1031,71 @@ describe('nanoviews', () => {
         items([])
 
         expect(container.innerHTML).toBe('<div><ul><li>nobody</li></ul></div>')
+      })
+
+      it('should hand the row through a transform with `as_`', () => {
+        const items = signal([
+          {
+            id: 1,
+            name: 'Yatoro'
+          },
+          {
+            id: 2,
+            name: 'Larl'
+          }
+        ])
+        const { container } = render(() => ul()(
+          for_(items, trackById)(
+            as_(record, ($player, $index) => li()($player.$name, ':', $index))
+          )
+        ))
+
+        expect(container.innerHTML).toBe('<div><ul><li>Yatoro:0</li><li>Larl:1</li></ul></div>')
+
+        // the transformed row is still the row: a write reaches the array
+        untracked(items)[0].name = 'x'
+        items([
+          {
+            id: 1,
+            name: 'Collapse'
+          },
+          {
+            id: 2,
+            name: 'Larl'
+          }
+        ])
+
+        expect(container.innerHTML).toBe('<div><ul><li>Collapse:0</li><li>Larl:1</li></ul></div>')
+      })
+
+      it('should keep a row written through `as_` writable', () => {
+        const items = signal([
+          {
+            id: 1,
+            name: '  Larl  '
+          }
+        ])
+
+        render(() => ul()(
+          for_(items, trackById)(
+            as_(record, ($player) => {
+              const name = untracked($player.$name)
+
+              if (name !== name.trim()) {
+                $player.$name(name.trim())
+              }
+
+              return li()($player.$name)
+            })
+          )
+        ))
+
+        expect(untracked(items)).toEqual([
+          {
+            id: 1,
+            name: 'Larl'
+          }
+        ])
       })
 
       describe('fuzz', () => {

--- a/packages/nanoviews/src/flow/for.ts
+++ b/packages/nanoviews/src/flow/for.ts
@@ -30,6 +30,20 @@ export function trackById(item: { id: unknown }) {
   return item.id
 }
 
+/**
+ * Hand the row through a transform before rendering it
+ * @param as - Function that transforms the row, eg `record`
+ * @param each_ - Function that renders the transformed row
+ * @returns Function to pass to `for_`
+ */
+/* @__NO_SIDE_EFFECTS__ */
+export function as_<Item, Index, Value>(
+  as: (item: Item) => Value,
+  each_: (value: Value, index: Index) => Child
+) {
+  return (item: Item, index: Index) => each_(as(item), index)
+}
+
 type AnyEach = (
   item: Accessor<unknown>,
   index: ReadableSignal<number>

--- a/todo.txt
+++ b/todo.txt
@@ -47,16 +47,7 @@
 - for_ duplicate track keys: unsupported by design, must keep failing loudly - the crash lands a step away from the cause, so it needs a clear throw at the point of detection
 - rework return slot$ to look like element/component? fn.prop is faster than {f,p}
 - util to transform static props to signal props?
-- additional arg for record in for$? as$
 - static index for untracked loop?
-
-for_($items)(
-  as_(record, ($item) => li()($item.$name))
-)
-
-for_($items)(
-  asRecord(($item) => li()($item.$name))
-)
 
 ## Perf
 


### PR DESCRIPTION
A row that needs a transform cannot be an expression. From this repo's own weather example:

```ts
for_(props.$suggestions, trackBy('label'))(
  ($city, index) => {
    const city = record($city)

    return li({ role: 'presentation' })(
      // …
    )
  }
)
```

Four lines of scaffolding — the braces, the `const`, the blank line, the `return` — around a body that is one expression. `as_` gives the expression back:

```ts
for_(props.$suggestions, trackBy('label'))(
  as_(record, (city, index) => li({ role: 'presentation' })(
    // …
  ))
)
```

## The whole thing

```ts
/* @__NO_SIDE_EFFECTS__ */
export function as_<Item, Index, Value>(
  as: (item: Item) => Value,
  each_: (value: Value, index: Index) => Child
) {
  return (item: Item, index: Index) => each_(as(item), index)
}
```

The transform is any function of the row, not `record` specifically. The row and index types are deliberately unconstrained, so one signature serves all three shapes `for_` hands out — the writable row, the readable one, and the static one.

The thing that decided this was worth having is that inference survives. `record` is itself generic, so the row type has to flow through two generic calls in a row before it reaches the callback. It does, with no type arguments written anywhere:

```ts
for_($cities, trackById)(
  as_(record, (city, index) => li()(city.$name, ':', index))
)
```

`city.$name` is `WritableSignal<string>` there — checked by giving it to a `number` and reading the error, not by looking at it.

## Tests

Two, both rendering for real: a row goes through `record`, the index arrives second, and a change to the array repaints; and — the one that matters — a row transformed by `as_` is still the row, so normalising `$player.$name` inside the body writes back into the items array.

## Size

**+17 B gzip** on all publics, and **nothing** on the average-usage bundle: `as_` is a separate export, so a consumer who does not import it does not pay for it. One brotli pin moves up a step; the rest stay.
