### PR TITLE
fix(kida): type `toAccessor` by what it actually returns

### DIFF
--- a/packages/kida/src/internals/types.ts
+++ b/packages/kida/src/internals/types.ts
@@ -5,7 +5,7 @@ import type {
   WritableSignal,
   ReadableSignal,
   Accessor,
-  AnyAccessor
+  AnyFn
 } from 'agera'
 
 export type { AnyFn } from 'agera'
@@ -40,10 +40,13 @@ export type ToSignal<T> = [T] extends [AnyWritableSignal]
       ? ReadableSignal<V>
       : WritableSignal<Exclude<T, AnyAccessorOrSignal>> | ToSignal<Extract<T, AnyAccessorOrSignal>>
 
-export type ToAccessor<T> = [T] extends [AnyAccessor]
+// Both of these test any function, not just a zero-argument one: the runtime
+// test behind them is `typeof value === 'function'`, so a callback is handed
+// back untouched exactly like an accessor is, and the type has to say the same
+export type ToAccessor<T> = [T] extends [AnyFn]
   ? T
-  : Accessor<Exclude<T, AnyAccessor>> | Extract<T, AnyAccessor>
+  : Accessor<Exclude<T, AnyFn>> | Extract<T, AnyFn>
 
-export type ToAccessorOrSignal<T> = [T] extends [AnyAccessor]
+export type ToAccessorOrSignal<T> = [T] extends [AnyFn]
   ? T
-  : WritableSignal<Exclude<T, AnyAccessor>> | Extract<T, AnyAccessor>
+  : WritableSignal<Exclude<T, AnyFn>> | Extract<T, AnyFn>


### PR DESCRIPTION
`toAccessor` and `toAccessorOrSignal` decide what to do with a `typeof` test:

```ts
export function toAccessor(source: unknown) {
  return isAccessor(source)
    ? source
    : () => source
}
```

`isAccessor` is `typeof value === 'function'`. It cannot tell an accessor from a callback, and it does not try — either one is handed back untouched.

The types said otherwise. They tested `AnyAccessor`, which is `Accessor<any>` — a **zero-argument** function. A callback takes an argument, so it is not assignable, so it fell through to the wrapping branch:

```ts
const wrapped = toAccessor((event: Event) => String(event.type))
// typed   Accessor<(event: Event) => string>
// is      (event: Event) => string
```

`toAccessorOrSignal` was wrong the same way, and worse — it claimed a `WritableSignal` of the callback.

Both now test `AnyFn`, which is what the runtime tests:

```ts
export type ToAccessor<T> = [T] extends [AnyFn]
  ? T
  : Accessor<Exclude<T, AnyFn>> | Extract<T, AnyFn>
```

Nothing else changes. A plain value still becomes `Accessor<T>`, an accessor or a signal still comes back as itself; only the case that was already lying is corrected.

Types only — every bundle in the chain is byte-identical, and no size pin moves. Checked across all eleven packages: lint, `tsc --noEmit` and the unit suites are green.

This matters beyond the two functions: `nanoviews`' `props$` reads props in accessor form with the same `typeof` rule, and it types its result with `ToAccessor`. Before this fix, a callback prop taken as `$onSelect` would have been typed as an accessor wrapping the callback rather than as the callback itself.
