### PR TITLE
feat(nanoviews): rename `$$children`, `$$slot` and `$$slots` to a trailing `$`

### DIFF
--- a/packages/nanoviews/.size-limit.json
+++ b/packages/nanoviews/.size-limit.json
@@ -16,13 +16,13 @@
     "name": "Average usage (Gzip)",
     "gzip": true,
     "path": "dist/index.js",
-    "import": "{ fragment, div, form, input, button, label, classList$, if_, for_, value$, $$children, effect }",
+    "import": "{ fragment, div, form, input, button, label, classList$, if_, for_, value$, children$, effect }",
     "limit": "3.8 kB"
   },
   {
     "name": "Average usage (Brotli)",
     "path": "dist/index.js",
-    "import": "{ fragment, div, form, input, button, label, classList$, if_, for_, value$, $$children, effect }",
+    "import": "{ fragment, div, form, input, button, label, classList$, if_, for_, value$, children$, effect }",
     "limit": "3.55 kB"
   }
 ]

--- a/packages/nanoviews/src/component/children.stories.ts
+++ b/packages/nanoviews/src/component/children.stories.ts
@@ -5,7 +5,7 @@ import {
 } from '@nanoviews/storybook'
 import { createElement } from '../elements/index.js'
 import {
-  $$slot,
+  slot$,
   getSlots
 } from './children.js'
 
@@ -17,7 +17,7 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-const TestSlot = (text: string) => $$slot(TestSlot, text)
+const TestSlot = (text: string) => slot$(TestSlot, text)
 
 export const NoSlot: Story = {
   render: nanoStory(
@@ -39,8 +39,8 @@ export const Slot: Story = {
   )
 }
 
-const PreSlot = (text: string) => $$slot(PreSlot, text)
-const PostSlot = (text: string) => $$slot(PostSlot, text)
+const PreSlot = (text: string) => slot$(PreSlot, text)
+const PostSlot = (text: string) => slot$(PostSlot, text)
 
 export const Slots: Story = {
   render: nanoStory(

--- a/packages/nanoviews/src/component/children.ts
+++ b/packages/nanoviews/src/component/children.ts
@@ -17,7 +17,7 @@ import { lazyChild } from '../internals/index.js'
  * @param render - Function to render block with given children
  * @returns Function that accepts children
  */
-export function $$children<
+export function children$<
   T extends Child,
   C extends unknown[] = Children
 >(render: Renderer<T, C>) {
@@ -41,7 +41,7 @@ export function isSlot(value: unknown): value is Slot<unknown, AnyFn> {
  * @param content - Slot content
  * @returns Slot
  */
-export function $$slot<
+export function slot$<
   C,
   // oxlint-disable-next-line typescript/no-explicit-any
   F extends (...args: any[]) => Slot<C, F>
@@ -98,7 +98,7 @@ export function getSlots<
  * @param render - Function to render block with given slots and children
  * @returns Function that accepts children
  */
-export function $$slots<
+export function slots$<
   T extends Child,
   D extends AnySlotDef[]
 >(


### PR DESCRIPTION
Effect attributes lost the `$$` prefix in #188 and took a trailing `$` instead — `classList$`, `value$`, `ref$`, `autoFocus$`. These three kept the old spelling:

```diff
-export function $$children<T extends Child, C extends unknown[] = Children>(render: Renderer<T, C>)
+export function children$<T extends Child, C extends unknown[] = Children>(render: Renderer<T, C>)

-export function $$slot<C, F extends (...args: any[]) => Slot<C, F>>(factory: F, content: C)
+export function slot$<C, F extends (...args: any[]) => Slot<C, F>>(factory: F, content: C)

-export function $$slots<T extends Child, D extends AnySlotDef[]>(slotDefs: [...D], render: RendererWithSlots<T, D>)
+export function slots$<T extends Child, D extends AnySlotDef[]>(slotDefs: [...D], render: RendererWithSlots<T, D>)
```

They are the names a component author writes most, so the inconsistency was in the most visible place.

## Cost

None. The package is not published yet, so the old names go rather than turn into aliases, and the rename is free at every measured entry:

| gzip | before | after |
|---|---:|---:|
| all publics | 7419 | 7417 |
| average usage | 3790 | 3790 |

The average-usage entry names its imports, so `$$children` there became `children$` too. One brotli pin moves down a step.

114 tests, lint and `tsc --noEmit` green.
