### PR TITLE
feat(nanoviews): rename the truthy and falsy narrowing types

### DIFF
--- a/packages/nanoviews/src/flow/if.ts
+++ b/packages/nanoviews/src/flow/if.ts
@@ -3,8 +3,8 @@ import {
   boolean
 } from 'kida'
 import type {
-  TruthyValueOrSignal,
-  FalsyValueOrSignal,
+  TruthySignalish,
+  FalsySignalish,
   Child
 } from '../internals/index.js'
 import { swap_ } from './swap.js'
@@ -22,14 +22,14 @@ export function if_<T>($value: T) {
    * @returns Block that renders decided child
    */
   return (
-    then_: (value: TruthyValueOrSignal<T>) => Child,
-    else_?: (value: FalsyValueOrSignal<T>) => Child
+    then_: (value: TruthySignalish<T>) => Child,
+    else_?: (value: FalsySignalish<T>) => Child
   ) => swap_(
     isAccessor($value) ? boolean($value) : $value as boolean,
     confition => (
       confition
-        ? then_($value as TruthyValueOrSignal<T>)
-        : else_?.($value as FalsyValueOrSignal<T>)
+        ? then_($value as TruthySignalish<T>)
+        : else_?.($value as FalsySignalish<T>)
     )
   )
 }

--- a/packages/nanoviews/src/internals/types/common.ts
+++ b/packages/nanoviews/src/internals/types/common.ts
@@ -31,13 +31,13 @@ export type AccessibleProps<T> = {
   [K in keyof T]?: Signalish<T[K]>
 }
 
-export type TruthySignal<T> = T extends Accessor<infer U>
+export type TruthyAccessor<T> = T extends Accessor<infer U>
   ? U extends FalsyValue
     ? never
     : T
   : never
 
-export type TruthyValueOrSignal<T> = T extends Accessor<infer U>
+export type TruthySignalish<T> = T extends Accessor<infer U>
   ? U extends FalsyValue
     ? never
     : T
@@ -45,13 +45,13 @@ export type TruthyValueOrSignal<T> = T extends Accessor<infer U>
     ? never
     : T
 
-export type FalsySignal<T> = T extends Accessor<infer U>
+export type FalsyAccessor<T> = T extends Accessor<infer U>
   ? U extends FalsyValue
     ? T
     : never
   : never
 
-export type FalsyValueOrSignal<T> = T extends Accessor<infer U>
+export type FalsySignalish<T> = T extends Accessor<infer U>
   ? U extends FalsyValue
     ? T
     : never


### PR DESCRIPTION
Four types in `nanoviews` narrow a value by whether it is truthy, and `if_` hands two of them to its branches:

```ts
export function if_<T>($value: T) {
  return (
    then_: (value: TruthySignalish<T>) => Child,
    else_?: (value: FalsySignalish<T>) => Child
  ) => …
}
```

Their names were wrong in two different ways.

`TruthyValueOrSignal` and `FalsyValueOrSignal` were named after `ValueOrAccessor`, which became `Signalish` in #210 — so they were left pointing at a union that no longer exists.

`TruthySignal` and `FalsySignal` were never about signals: like their siblings they test `Accessor`, and answer `never` for anything that is not one.

```diff
-export type TruthySignal<T> = T extends Accessor<infer U>
+export type TruthyAccessor<T> = T extends Accessor<infer U>
   ? U extends FalsyValue
     ? never
     : T
   : never

-export type TruthyValueOrSignal<T> = T extends Accessor<infer U>
+export type TruthySignalish<T> = T extends Accessor<infer U>
   ? U extends FalsyValue
     ? never
     : T
   : T extends FalsyValue
     ? never
     : T
```

The suffix now carries the only thing that separates the two pairs: `-Accessor` requires an accessor and gives `never` to anything else, `-Signalish` also takes a plain value. That is the same opposition `AccessorValue` and `SignalishValue` already carry.

No aliases: the package is not published yet. `TruthyAccessor` and `FalsyAccessor` have no consumer anywhere in the monorepo — they could be deleted instead of renamed, which is a separate call to make.

Types only: every bundle is byte-identical and no pin moves. 114 tests, lint and `tsc --noEmit` green.
