### PR TITLE
perf(nanoviews): create the effect attribute registry on first use

### DIFF
--- a/packages/nanoviews/src/internals/elements/attributes.ts
+++ b/packages/nanoviews/src/internals/elements/attributes.ts
@@ -68,7 +68,7 @@ function setEventListener(element: Element, name: string, value: TargetEventHand
 export function setAttributes<A extends object>(element: Element, attributes: A) {
   for (const key in attributes) {
     const value = (attributes as Attributes)[key]
-    const tEffectAttr = effectAttributes.get(key)
+    const tEffectAttr = effectAttributes?.get(key)
 
     if (tEffectAttr !== undefined) {
       tEffectAttr(element, value, attributes as Attributes)

--- a/packages/nanoviews/src/internals/elements/effectAttribute.ts
+++ b/packages/nanoviews/src/internals/elements/effectAttribute.ts
@@ -3,7 +3,11 @@ import type {
   EffectAttributeCallback
 } from '../types/index.js'
 
-export const effectAttributes = new Map<EffectAttributeId, EffectAttributeCallback>()
+// The registry is born on the first effect attribute, so an app that creates
+// none leaves nothing behind: with `createEffectAttribute` shaken out, the
+// binding is a `let` nothing ever assigns, and the lookup below it folds away
+// oxlint-disable-next-line import/no-mutable-exports
+export let effectAttributes: Map<EffectAttributeId, EffectAttributeCallback> | undefined
 
 /**
  * Create effect attribute
@@ -17,7 +21,7 @@ export function createEffectAttribute<
   TargetElement extends Element,
   Value
 >(id: ID, callback: EffectAttributeCallback<TargetElement, Value>) {
-  effectAttributes.set(id, callback as EffectAttributeCallback)
+  (effectAttributes ??= new Map()).set(id, callback as EffectAttributeCallback)
 
   return id
 }


### PR DESCRIPTION
`setAttributes` asks the effect attribute registry about every attribute it sets:

```ts
for (const key in attributes) {
  const value = (attributes as Attributes)[key]
  const tEffectAttr = effectAttributes.get(key)
  …
}
```

The only thing that ever puts anything in that registry is `createEffectAttribute`. An app that calls it never sees the empty case; an app that doesn't carries an empty `Map` and pays a `Map.get` per attribute for an answer that can only be `undefined`.

```diff
-export const effectAttributes = new Map<EffectAttributeId, EffectAttributeCallback>()
+export let effectAttributes: Map<EffectAttributeId, EffectAttributeCallback> | undefined

 export function createEffectAttribute<…>(id: ID, callback: …) {
-  effectAttributes.set(id, callback as EffectAttributeCallback)
+  (effectAttributes ??= new Map()).set(id, callback as EffectAttributeCallback)
```

The registry is now born on the first `createEffectAttribute`. That is what makes it disappear: with the function shaken out, nothing assigns the binding, so the bundler can see it is `undefined` and fold `effectAttributes?.get(key)` away with it.

### Measured

In the js-framework-benchmark app, which creates no effect attributes, the bundle goes **12910 → 12861 bytes**. `const rn=new Map` is gone, and so is one of the five `.get(` calls — the three that remain are the selector's key map and the loop's `lookupMap`, both real. On the hot path that is one `Map.get` per attribute, nine per row.

The package's own size entries do not move: `All publics` imports `createEffectAttribute`, so the `Map` is still created there, just later. Gzip 7553 → 7552, average usage unchanged. The win belongs to the consumer, not to our own measurement.

One note on the pins: `All publics (Brotli)` reads 6750 against a pin of 6750 — it passes, and by the rounding rule the pin is right, but there is no slack left. The move itself (6704 → 6750 while gzip goes down by a byte) is the brotli noise band we already decided not to steer by. Raising that pin is a separate call.

### Why this one first

It comes out of a perf review of all twelve benchmark cases. By CPU it is small — the profile of `07_create10k` puts the ceiling at about 1.5 ms out of 221 — but it is the only item on the list that costs negative bytes, so it goes in ahead of the things that cost some.

Lint (`no-mutable-exports` suppressed on the one line, the way `system.ts:517` already does), `tsc --noEmit` and 127 tests are green. Pins across every package: no drift.
