### PR TITLE
perf(agera,nanoviews): write a row index past the signal when nothing watches it

### DIFF
--- a/packages/agera/.size-limit.json
+++ b/packages/agera/.size-limit.json
@@ -4,13 +4,13 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "3.15 kB"
+    "limit": "3.2 kB"
   },
   {
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "2.9 kB"
+    "limit": "2.95 kB"
   },
   {
     "name": "Signal (Gzip)",

--- a/packages/agera/src/index.ts
+++ b/packages/agera/src/index.ts
@@ -9,7 +9,8 @@ export {
   trigger,
   onSignal,
   createSignal,
-  computedOper
+  computedOper,
+  setUnwatchedValue
 } from './internals/system.js'
 export * from './signal.js'
 export * from './modes.js'

--- a/packages/agera/src/internals/system.ts
+++ b/packages/agera/src/internals/system.ts
@@ -433,6 +433,22 @@ export function onSignal(callback: ($signal: AnySignal) => void) {
 }
 
 /**
+ * Write a value into a signal nothing watches yet.
+ *
+ * Only for a node with no subscribers: nothing is notified. The value is
+ * stored as it is, so a function is kept and not run as a reducer.
+ * @private
+ * @param node - Node of the signal to write to
+ * @param value - Value to write
+ */
+export function setUnwatchedValue<T>(node: SignalNode<T>, value: T): void {
+  // With nobody to tell, a write is the two fields a later read looks at: the
+  // pending value it will pick up, and the flag that sends it to pick it up
+  node.pendingValue = value
+  node.flags = MutableFlag | DirtyFlag
+}
+
+/**
  * Create a signal function over a reactive node. The node is the operator's
  * `this`, so whatever a call site needs at read or write time lives on the
  * node and a signal costs one object and one bound function, nothing else.

--- a/packages/agera/src/signal.spec.ts
+++ b/packages/agera/src/signal.spec.ts
@@ -18,6 +18,7 @@ import {
   mountable,
   onMounted,
   selector,
+  setUnwatchedValue,
   signal,
   startScope,
   stopScope,
@@ -696,6 +697,44 @@ describe('agera', () => {
         $double(10)
 
         expect($num()).toBe(5)
+      })
+    })
+
+    describe('setUnwatchedValue', () => {
+      it('should hand the value to the next read', () => {
+        const $num = signal(1)
+
+        setUnwatchedValue($num.node, 2)
+
+        expect($num()).toBe(2)
+      })
+
+      it('should store a function instead of running it as a reducer', () => {
+        const reducer = vi.fn((value: number) => value + 1)
+        const $fn = signal<unknown>(1)
+
+        setUnwatchedValue($fn.node, reducer)
+
+        expect($fn()).toBe(reducer)
+        expect(reducer).not.toHaveBeenCalled()
+      })
+
+      it('should leave a later write to the signal working', () => {
+        const $num = signal(1)
+        const effectFn = vi.fn()
+
+        setUnwatchedValue($num.node, 2)
+
+        const stop = effectScope(() => effect(() => effectFn($num())))
+
+        expect(effectFn).toHaveBeenCalledExactlyOnceWith(2)
+
+        $num(3)
+
+        expect(effectFn).toHaveBeenCalledTimes(2)
+        expect(effectFn).toHaveBeenLastCalledWith(3)
+
+        stop()
       })
     })
 

--- a/packages/nanoviews/.size-limit.json
+++ b/packages/nanoviews/.size-limit.json
@@ -10,14 +10,14 @@
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "6.75 kB"
+    "limit": "6.8 kB"
   },
   {
     "name": "Average usage (Gzip)",
     "gzip": true,
     "path": "dist/index.js",
     "import": "{ fragment, div, form, input, button, label, classList$, if_, for_, value$, children$, effect }",
-    "limit": "3.8 kB"
+    "limit": "3.85 kB"
   },
   {
     "name": "Average usage (Brotli)",

--- a/packages/nanoviews/src/internals/flow/loop.ts
+++ b/packages/nanoviews/src/internals/flow/loop.ts
@@ -17,7 +17,8 @@ import {
   createSignal,
   isWritable,
   nextValue,
-  assignIndex
+  assignIndex,
+  setUnwatchedValue
 } from 'kida'
 import type {
   Child,
@@ -239,7 +240,14 @@ function reconcile(
     }
 
     if (item.i.node.pendingValue !== i) {
-      item.i(i)
+      // A row's index is written on every pass and read only by a row that
+      // put it on screen, so the write skips the signal whenever nothing is
+      // there to be told about it
+      if (item.i.node.subs === undefined) {
+        setUnwatchedValue(item.i.node, i)
+      } else {
+        item.i(i)
+      }
     }
 
     if (item.v.node.pendingValue !== value) {

--- a/packages/store/.size-limit.json
+++ b/packages/store/.size-limit.json
@@ -10,7 +10,7 @@
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "5.8 kB"
+    "limit": "5.85 kB"
   },
   {
     "name": "Signal (Gzip)",


### PR DESCRIPTION
Every reconcile pass writes the index of every row that moved:

```ts
if (item.i.node.pendingValue !== i) {
  item.i(i)
}
```

`item.i` is a signal, so that write is a bound call, a rest array and a reducer check — and then it arrives at a node with `subs === undefined` and has nothing to notify. A row's index is only watched when the row put it on screen; in a list that does not, every one of those writes pays the whole path for nothing.

```diff
 if (item.i.node.pendingValue !== i) {
-  item.i(i)
+  if (item.i.node.subs === undefined) {
+    setUnwatchedValue(item.i.node, i)
+  } else {
+    item.i(i)
+  }
 }
```

`setUnwatchedValue` is the two fields a later read looks at — the pending value it will pick up, and the flag that sends it to pick it up. It lives in agera, next to `createSignal` and marked `@private` the same way, because `MutableFlag | DirtyFlag` is agera's write protocol and hardcoding it in the loop would break silently the day that protocol changes.

### Measured

`06_remove-one-1k`, 60 iterations per arm, both arms built and run back to back in one session:

| | script | 95% CI of the difference | p |
|---|---|---|---|
| baseline | 1.00 ms | | |
| this branch | **0.80 ms** | [−0.30; −0.10] | **0.004** |
| `01_run1k` (control) | 24.35 → 24.60 ms | [−0.30; +0.95] | 0.475 |

−20% on the case's script, and the control confirms it is not drift. In the reference run solid and vue-vapor both sit at 1.0 ms there, so this moves nanoviews from level with them to ahead.

`06` is also the only case this reaches: indices are rewritten when a row is removed. In `03` the values change and the indices do not, in `08` the new rows are appended and the old ones keep their index, `05` writes two, and in `01`/`02` the rows are born.

### Cost

+26 B gzip for a nanoviews bundle (7552 → 7578), +23 B for agera's `All publics` entry. An agera consumer that does not import the helper pays nothing — `Signal` stays at 1426 B and `Minimal set` at 1625 B, byte for byte.

Five pins move to the next fifty: agera `All publics` gzip and brotli, nanoviews `All publics` brotli and `Average usage` gzip, store `All publics` brotli.

Three tests cover the new export: the value reaches the next read, a function is stored rather than run as a reducer, and a normal write still notifies afterwards. Lint, `tsc --noEmit`, and every package's suite are green; no pin is left adrift.
