### PR TITLE
refactor(nanoviews): drop the unreachable empty check around element children

### DIFF
--- a/packages/nanoviews/src/internals/elements/element.ts
+++ b/packages/nanoviews/src/internals/elements/element.ts
@@ -52,13 +52,9 @@ export function elementChildren(
   result: Element | DocumentFragment,
   ...children: Children
 ) {
-  const len = children.length
-
-  if (len) {
-    for (let i = 0, node: ChildNode | DocumentFragment | EmptyValue; i < len; i++) {
-      if (node = childToNode(children[i])) {
-        this.appendChild(node)
-      }
+  for (let i = 0, len = children.length, node: ChildNode | DocumentFragment | EmptyValue; i < len; i++) {
+    if (node = childToNode(children[i])) {
+      this.appendChild(node)
     }
   }
 


### PR DESCRIPTION
`elementChildren` guarded its loop against having no children:

```ts
const len = children.length

if (len) {
  for (let i = 0, node: ChildNode | DocumentFragment | EmptyValue; i < len; i++) {
    if (node = childToNode(children[i])) {
      this.appendChild(node)
    }
  }
}
```

The loop asks the same question in its own condition: with no children `i < len` is false on the first look and the body never runs. The guard has no case of its own — it can only ever agree with the loop it wraps.

```diff
-  const len = children.length
-
-  if (len) {
-    for (let i = 0, node: ChildNode | DocumentFragment | EmptyValue; i < len; i++) {
-      if (node = childToNode(children[i])) {
-        this.appendChild(node)
-      }
-    }
-  }
+  for (let i = 0, len = children.length, node: ChildNode | DocumentFragment | EmptyValue; i < len; i++) {
+    if (node = childToNode(children[i])) {
+      this.appendChild(node)
+    }
+  }
```

The length moves into the loop's initialiser, so it is still read once.

### Size

The built package goes from 37488 to 37465 bytes, and the js-framework-benchmark app bundle from 12861 to 12850 — 23 bytes of code, 11 of them reaching an app.

The `All publics` gzip entry moves the other way, 7552 → 7558, which is compression context rather than code: the same twenty-three bytes are gone from the input. It stays well under its pin and no pin moves.

### Where it comes from

This is what is left of a five-item micro-pack from a perf review, after measuring each item on its own:

| | package raw | `All publics` gzip | app bundle |
|---|---|---|---|
| **drop the `if (len)`** | **−23** | +6 | **−11** |
| `child.c === true` over `'c' in child` | — | +5 | +1 |
| `key[0] === 'o'` over `startsWith('on')` | +12 | +4 | +3 |
| caching `key.slice(1)` in the record trap | — | — | +18 |

The other three cost bytes to save work too small for the benchmark to resolve, so they are not here. This one is the only one that removes something rather than adding, and it is also the one the house rule asks for: a branch no realistic caller can reach is dead weight.

Lint, `tsc --noEmit` and 127 tests are green.
