### PR TITLE
perf(nanoviews): clear a row range with `replaceChildren`

### DIFF
--- a/packages/nanoviews/.size-limit.json
+++ b/packages/nanoviews/.size-limit.json
@@ -17,7 +17,7 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "{ fragment, div, form, input, button, label, classList$, if_, for_, value$, children$, effect }",
-    "limit": "3.8 kB"
+    "limit": "3.85 kB"
   },
   {
     "name": "Average usage (Brotli)",

--- a/packages/nanoviews/src/internals/elements/child.ts
+++ b/packages/nanoviews/src/internals/elements/child.ts
@@ -105,5 +105,14 @@ export function remove(start: ChildNode, end: Node): void {
 }
 
 export function removeBetween(start: Node, end: Node): void {
-  remove(start.nextSibling!, end.previousSibling!)
+  const parent = start.parentNode!
+
+  // When the pair stands at the ends of its parent, everything between them
+  // is everything the parent holds: one call sets the parent back to the two
+  // markers, and the browser drops the rest without a range to walk
+  if (start === parent.firstChild && end === parent.lastChild) {
+    parent.replaceChildren(start as ChildNode, end as ChildNode)
+  } else {
+    remove(start.nextSibling!, end.previousSibling!)
+  }
 }


### PR DESCRIPTION
Clearing a period walks a `Range`:

```ts
export function removeBetween(start: Node, end: Node): void {
  remove(start.nextSibling!, end.previousSibling!)
}
```

`start` and `end` are the two text markers a period keeps its place with, so what has to go is everything between them. But when those markers stand at the ends of their parent, everything between them is everything the parent holds — and the range is saying the long way what one call says directly.

```diff
 export function removeBetween(start: Node, end: Node): void {
-  remove(start.nextSibling!, end.previousSibling!)
+  const parent = start.parentNode!
+
+  if (start === parent.firstChild && end === parent.lastChild) {
+    parent.replaceChildren(start as ChildNode, end as ChildNode)
+  } else {
+    remove(start.nextSibling!, end.previousSibling!)
+  }
 }
```

An empty range behaves now too: with nothing between the markers, `start.nextSibling` is `end` and `end.previousSibling` is `start`, so the old path asked for a range that runs backwards.

### Measured

`09_clear1k_x8`, 40 iterations per arm, two rounds with the arms alternating so a drift inside the session cannot pass for an effect:

| | baseline | this branch | difference | 95% CI |
|---|---|---|---|---|
| script | 34.90 ms | **31.65 ms** | −3.25 | [−4.00; −2.40] |
| total | 40.10 ms | **36.60 ms** | −3.50 | [−4.10; −2.60] |

Both rounds agree. `02_replace1k` was measured alongside as a control and did not move (−0.55, CI [−1.60; +0.55]) — `removeBetween` runs once per period swap there, not on a hot path.

The case profile says why the ceiling is where it is: of 31 ms of JS in `09`, `Range.deleteContents` was 27.98 and the whole reactive teardown of a thousand rows was 2.8. This takes about half of the 6.8 ms gap to vue-vapor; the rest is the difference between `replaceChildren` and solid's `textContent = ""` plus that teardown, which stays.

Weighted geometric mean: 1.139 → 1.129.

### Cost

+30 B gzip (7558 → 7588). One pin moves: `Average usage (Gzip)` 3.8 → 3.85 kB. `All publics` stays under its own.

The same trick does not carry to `remove`: in the tail of a reconcile the new rows are already in front of the old ones, so the parent holds `[start, …new, …old, end]` and the range being deleted is far from all of the children.

Lint, `tsc --noEmit` and 127 tests are green.
