### PR TITLE
feat(nanoviews): hand the tracking key to the row

### DIFF
--- a/packages/nanoviews/.size-limit.json
+++ b/packages/nanoviews/.size-limit.json
@@ -10,7 +10,7 @@
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "6.75 kB"
+    "limit": "6.8 kB"
   },
   {
     "name": "Average usage (Gzip)",
@@ -23,6 +23,6 @@
     "name": "Average usage (Brotli)",
     "path": "dist/index.js",
     "import": "{ fragment, div, form, input, button, label, classList$, if_, for_, value$, children$, effect }",
-    "limit": "3.55 kB"
+    "limit": "3.6 kB"
   }
 ]

--- a/packages/nanoviews/src/flow/for.spec.ts
+++ b/packages/nanoviews/src/flow/for.spec.ts
@@ -1033,6 +1033,82 @@ describe('nanoviews', () => {
         expect(container.innerHTML).toBe('<div><ul><li>nobody</li></ul></div>')
       })
 
+      it('should hand the tracking key to the row', () => {
+        const items = signal([
+          {
+            id: 'a',
+            name: 'Yatoro'
+          },
+          {
+            id: 'b',
+            name: 'Larl'
+          }
+        ])
+        const { container } = render(() => ul()(
+          for_(items, trackById)(
+            ($player, $index, key) => li()(key, ':', () => $player().name, ':', $index)
+          )
+        ))
+
+        expect(container.innerHTML).toBe('<div><ul><li>a:Yatoro:0</li><li>b:Larl:1</li></ul></div>')
+
+        // The key is the row's own: it stays with the row wherever the row
+        // goes, while the index follows the position
+        items([
+          {
+            id: 'b',
+            name: 'Larl'
+          },
+          {
+            id: 'a',
+            name: 'Yatoro'
+          }
+        ])
+
+        expect(container.innerHTML).toBe('<div><ul><li>b:Larl:0</li><li>a:Yatoro:1</li></ul></div>')
+      })
+
+      it('should hand the index as the key when there is no tracker', () => {
+        const items = signal(['Yatoro', 'Larl'])
+        const { container } = render(() => ul()(
+          for_(items)(
+            ($player, $index, key) => li()(key, ':', $player, ':', $index)
+          )
+        ))
+
+        expect(container.innerHTML).toBe('<div><ul><li>0:Yatoro:0</li><li>1:Larl:1</li></ul></div>')
+      })
+
+      it('should hand the index as the key of a static array row', () => {
+        const { container } = render(() => ul()(
+          for_(['Yatoro', 'Larl'])(
+            (player, index, key) => li()(key, ':', player, ':', index)
+          )
+        ))
+
+        expect(container.innerHTML).toBe('<div><ul><li>0:Yatoro:0</li><li>1:Larl:1</li></ul></div>')
+      })
+
+      it('should carry the tracking key through `as_`', () => {
+        const items = signal([
+          {
+            id: 'a',
+            name: 'Yatoro'
+          },
+          {
+            id: 'b',
+            name: 'Larl'
+          }
+        ])
+        const { container } = render(() => ul()(
+          for_(items, trackById)(
+            as_(record, ($player, $index, key) => li()(key, ':', $player.$name, ':', $index))
+          )
+        ))
+
+        expect(container.innerHTML).toBe('<div><ul><li>a:Yatoro:0</li><li>b:Larl:1</li></ul></div>')
+      })
+
       it('should hand the row through a transform with `as_`', () => {
         const items = signal([
           {

--- a/packages/nanoviews/src/flow/for.ts
+++ b/packages/nanoviews/src/flow/for.ts
@@ -16,8 +16,8 @@ import {
  * @param key - The key to track the item by
  * @returns A function that returns the value of the key in the item
  */
-export function trackBy<T extends string>(key: T) {
-  return (item: { [K in T]: unknown }) => item[key]
+export function trackBy<K extends string>(key: K) {
+  return <T>(item: { [P in K]: T }) => item[key]
 }
 
 /**
@@ -26,7 +26,7 @@ export function trackBy<T extends string>(key: T) {
  * @param item.id - The id of the item
  * @returns The id of the item
  */
-export function trackById(item: { id: unknown }) {
+export function trackById<T>(item: { id: T }) {
   return item.id
 }
 
@@ -37,31 +37,39 @@ export function trackById(item: { id: unknown }) {
  * @returns Function to pass to `for_`
  */
 /* @__NO_SIDE_EFFECTS__ */
-export function as_<Item, Index, Value>(
+export function as_<Item, Index, Key, Value>(
   as: (item: Item) => Value,
-  each_: (value: Value, index: Index) => Child
+  each_: (value: Value, index: Index, key: Key) => Child
 ) {
-  return (item: Item, index: Index) => each_(as(item), index)
+  return (item: Item, index: Index, key: Key) => each_(as(item), index, key)
 }
 
+// The key comes third because it is the one thing about a row that never
+// changes: the row is the row the tracker named, and a different key is a
+// different row. Without a tracker the key is the position, which is what
+// the row is identified by then, so it and the index signal never disagree
 type AnyEach = (
   item: Accessor<unknown>,
-  index: ReadableSignal<number>
+  index: ReadableSignal<number>,
+  key: unknown
 ) => Child
 
-type ReadableEach<T> = (
+type ReadableEach<T, K> = (
   item: Accessor<T>,
-  index: ReadableSignal<number>
+  index: ReadableSignal<number>,
+  key: K
 ) => Child
 
-type WritableEach<T> = (
+type WritableEach<T, K> = (
   item: WritableSignal<T>,
-  index: ReadableSignal<number>
+  index: ReadableSignal<number>,
+  key: K
 ) => Child
 
 type StaticEach<T> = (
   item: T,
-  index: number
+  index: number,
+  key: number
 ) => Child
 
 type UnknownTrack = (item: unknown, index: number) => unknown
@@ -70,19 +78,19 @@ type UnknownTrack = (item: unknown, index: number) => unknown
 // a widening of the first: `WritableSignal<T[]>` does not fit
 // `WritableSignal<T[] | EmptyValue>`, and widening would take the rows of
 // every existing caller down to read-only
-export function for_<T>(
+export function for_<T, K = number>(
   $items: WritableSignal<T[]> | WritableSignal<T[] | EmptyValue>,
-  track?: (item: T, index: number) => unknown
+  track?: (item: T, index: number) => K
 ): (
-  each_: WritableEach<T>,
+  each_: WritableEach<T, K>,
   else_?: () => Child
 ) => Child
 
-export function for_<T>(
+export function for_<T, K = number>(
   $items: Accessor<T[] | EmptyValue>,
-  track?: (item: T, index: number) => unknown
+  track?: (item: T, index: number) => K
 ): (
-  each_: ReadableEach<T>,
+  each_: ReadableEach<T, K>,
   else_?: () => Child
 ) => Child
 
@@ -94,7 +102,11 @@ export function for_<T>(
 ) => Child
 
 /**
- * Iterate over items and render each item
+ * Iterate over items and render each item.
+ *
+ * The render function is given the row, its index signal and the key the
+ * tracker named it by - a plain value, because a row keeps its key for as
+ * long as it lives.
  * @param $items - Target items
  * @param track - Tracker function to identify items
  * @returns Function to receive each_ and else_ functions
@@ -113,5 +125,9 @@ export function for_(
   return (
     each_: StaticEach<unknown>,
     else_?: () => Child
-  ) => ($items?.length ? fragment(...$items.map(each_)) : else_?.())
+  ) => (
+    $items?.length
+      ? fragment(...$items.map((item, index) => each_(item, index, index)))
+      : else_?.()
+  )
 }

--- a/packages/nanoviews/src/internals/flow/loop.ts
+++ b/packages/nanoviews/src/internals/flow/loop.ts
@@ -94,7 +94,8 @@ type LookupMap = Map<unknown, LoopItem>
 
 type AnyEach = (
   item: Accessor<unknown>,
-  index: ReadableSignal<number>
+  index: ReadableSignal<number>,
+  key: unknown
 ) => Child
 
 type UnknownTrack = (item: unknown, index: number) => unknown
@@ -218,7 +219,7 @@ function reconcile(
       }
 
       row.d = deferScope(() => {
-        insertChildBeforeAnchor(each_($row, $index), insertAnchor, row)
+        insertChildBeforeAnchor(each_($row, $index, key), insertAnchor, row)
 
         // Every row holds a place in the DOM, so a row that rendered nothing
         // still has one to be moved to, inserted before and removed with


### PR DESCRIPTION
A row is the row its tracker named. The key is the one thing about it that cannot change — a different key is a different row — and until now the loop kept it to itself:

```ts
for_($data, trackById)(
  ($row, $index) => {
    const { $id, $label } = record($row)

    return tr({ class: () => $isSelected($id()) ? 'danger' : '' })(
      td({ class: 'col-md-1' })($id),
      …
```

`$id` is a signal over a value that was known before the row existed and will never move. It costs a child signal, an effect and links, on every row, to read something the loop already had. The alternative — closing over the item the row was built from — is wrong the moment the row is reused for another item.

So the key comes third, as a plain value:

```ts
for_($data, trackById)(
  ($row, $index, id) => tr({ class: () => $isSelected(id) ? 'danger' : '' })(
    td({ class: 'col-md-1' })(id),
    …
```

Three details:

- **`as_` carries it through.** `as_(record, ($row, $index, key) => …)` works the same.
- **The static arm hands over the index**, which is the key a list without a tracker is reconciled by. That arm used to pass `each_` straight to `Array#map`, so a third parameter received the array — a trap for anyone who ever wrote one.
- **`trackById` and `trackBy` became generic** over what they return. They were typed `=> unknown`, which would have made the key `unknown` and the whole thing useless.

Without a tracker the key equals the index and the two never disagree: the lookup is keyed by position then, so the row at position `i` is always the one whose key is `i`.

### Measured

The row's key is only worth something to a component that takes it, so this was measured with the benchmark app rewritten to use it (a separate PR). 30 iterations per arm, two rounds with the arms alternating:

| case | script before | script after | 95% CI |
|---|---|---|---|
| 01 create 1k | 24.70 | **20.00** (−19%) | [−5.05; −3.95] |
| 02 replace all | 34.95 | **30.50** (−13%) | [−6.15; −3.60] |
| 07 create 10k | 205.05 | **186.25** (−9%) | [−24.70; −14.05] |
| 08 append 1k | 25.15 | **21.30** (−15%) | [−4.60; −3.15] |

`22_run-memory` goes from 3.449 MB to 3.083 — 366 KB less for a thousand rows, with both rounds agreeing to the third decimal.

What leaves each row is the whole reactive apparatus that existed only to deliver the id: the proxy trap, a child computed, an effect and three links.

### Cost

+11 B gzip (7558 → 7569). No pin moves. If #216 lands first its `Average usage` pin already covers the pair; whichever goes second wants its pins re-checked after the rebase.

Four tests: the key in the reactive arm and that it stays with a row across a reorder, the index as the key without a tracker, the same for a static array, and the key through `as_`. Lint, `tsc --noEmit` and 131 tests are green.
