### PR TITLE
perf(benchmark-nanoviews): take the row key and drop `record`

### DIFF
--- a/examples/benchmark/nanoviews/src/app.js
+++ b/examples/benchmark/nanoviews/src/app.js
@@ -1,7 +1,6 @@
 /* oxlint-disable */
 import {
   signal,
-  record,
   selector,
   deleteIndex,
   updateArray,
@@ -220,40 +219,33 @@ export function App(ref = {}) {
     })(
       tbody()(
         for_($data, item => item.id)(
-          ($row, $index) => {
-            const {
-              $id,
-              $label
-            } = record($row)
-
-            return tr({
-              class: () => $isSelected($id()) ? 'danger' : ''
-            })(
-              td({ class: 'col-md-1' })(
-                $id
-              ),
-              td({ class: 'col-md-4' })(
-                a({
-                  onClick() {
-                    $selected($id())
-                  }
-                })(
-                  $label
-                )
-              ),
-              td({ class: 'col-md-1' })(
-                a({
-                  onClick() {
-                    remove($index())
-                  }
-                })(
-                  'Delete'
-                  // span({ class: 'glyphicon glyphicon-remove', 'aria-hidden': true })
-                )
-              ),
-              td({ class: 'col-md-6' })
-            )
-          }
+          ($row, $index, id) => tr({
+            class: () => $isSelected(id) ? 'danger' : ''
+          })(
+            td({ class: 'col-md-1' })(
+              id
+            ),
+            td({ class: 'col-md-4' })(
+              a({
+                onClick() {
+                  $selected(id)
+                }
+              })(
+                () => $row().label
+              )
+            ),
+            td({ class: 'col-md-1' })(
+              a({
+                onClick() {
+                  remove($index())
+                }
+              })(
+                'Delete'
+                // span({ class: 'glyphicon glyphicon-remove', 'aria-hidden': true })
+              )
+            ),
+            td({ class: 'col-md-6' })
+          )
         )
       )
     ),


### PR DESCRIPTION
The row of the benchmark table needs two things from its item: the `id`, which is the key it is tracked by, and the `label`. It was taking both through `record`:

```js
($row, $index) => {
  const { $id, $label } = record($row)

  return tr({ class: () => $isSelected($id()) ? 'danger' : '' })(
    td({ class: 'col-md-1' })($id),
    …
```

So every row carried a proxy, two child signals, two effects and the links behind them — for one value that never changes and one that is rendered in a single place.

```js
($row, $index, id) => tr({ class: () => $isSelected(id) ? 'danger' : '' })(
  td({ class: 'col-md-1' })(id),
  td({ class: 'col-md-4' })(
    a({ onClick() { $selected(id) } })(
      () => $row().label
    )
  ),
  …
```

The id arrives as the row's key (#217) and the label is read off the row.

### Is dropping `record` for the label safe?

`record` gives a child *computed*, so it can hold a text binding still when the row object changes but that field does not. `() => $row().label` re-runs the binding on any change to the row.

In this app that saving never happens: `partialUpdate` builds a new object with `assignKey` for every tenth row only, so the hundred rows that get a new object are exactly the hundred whose label changed. The other nine hundred keep their identity and the reconcile does not write to them at all. The measurement agrees — `03_update10th1k_x16`, the one case where the dedup could have paid off, got slightly **faster**: 3.00 ms → 2.90, CI [−0.30; −0.05].

`record` still earns its proxy when a row has several fields to write back, or a field that changes far less often than the row it sits in. For one field that is only rendered, it does not.

### Measured

Two changes, measured separately, each with 30 iterations per arm and two rounds with the arms alternating.

| case | before | with the key | and without `record` |
|---|---|---|---|
| 01 create 1k, script | 24.70 | 20.00 | **19.50** |
| 02 replace all, script | 34.95 | 30.50 | 30.05 |
| 07 create 10k, script | 205.05 | 186.25 | **181.60** |
| 08 append 1k, script | 25.15 | 21.30 | 21.15 |
| 22 run memory | 3.449 MB | 3.083 | **2.943** |

The app bundle goes 12938 B → 11982: with the last consumer gone, the whole `record` machinery leaves it.

Together with #216 the weighted geometric mean moves 1.139 → 1.103, which puts nanoviews ahead of arrow-js. Computed conservatively: only the measured `script` deltas are taken off the reference totals, since none of this touches paint and `07`'s paint swings by ±40 ms between sessions.
