### PR TITLE
feat(nanoviews): add `match_` for a cascade of conditions

### DIFF
--- a/packages/nanoviews/.size-limit.json
+++ b/packages/nanoviews/.size-limit.json
@@ -4,7 +4,7 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "7.6 kB"
+    "limit": "7.7 kB"
   },
   {
     "name": "All publics (Brotli)",

--- a/packages/nanoviews/src/flow/index.ts
+++ b/packages/nanoviews/src/flow/index.ts
@@ -1,5 +1,6 @@
 export * from './swap.js'
 export * from './if.js'
 export * from './switch.js'
+export * from './match.js'
 export * from './for.js'
 export * from './throw.js'

--- a/packages/nanoviews/src/flow/match.spec.ts
+++ b/packages/nanoviews/src/flow/match.spec.ts
@@ -1,0 +1,166 @@
+import {
+  describe,
+  it,
+  expect,
+  vi
+} from 'vitest'
+import { composeStories } from '@nanoviews/storybook'
+import { render } from '@nanoviews/testing-library'
+import {
+  signal,
+  batch
+} from 'kida'
+import { b } from '../elements/elements.js'
+import { default_ } from './switch.js'
+import * as Stories from './match.stories.js'
+import {
+  when_,
+  match_
+} from './match.js'
+
+const {
+  StaticValue,
+  ReactiveValue,
+  ReactiveValueWithoutDefault,
+  CaseValue
+} = composeStories(Stories)
+
+describe('nanoviews', () => {
+  describe('flow', () => {
+    describe('match', () => {
+      it('should handle static value', () => {
+        const { container } = render(StaticValue())
+
+        expect(container.innerHTML).toBe('<div><b>Ready</b></div>')
+      })
+
+      it('should handle reactive value', () => {
+        const loading = signal(true)
+        const error = signal(false)
+        const { container } = render(ReactiveValue({
+          loading,
+          error
+        }))
+
+        expect(container.innerHTML).toBe('<div><i>Loading</i></div>')
+
+        loading(false)
+
+        expect(container.innerHTML).toBe('<div>Ready</div>')
+
+        error(true)
+
+        expect(container.innerHTML).toBe('<div><b>Error</b></div>')
+      })
+
+      it('should render nothing when no case holds and there is no default', () => {
+        const loading = signal(true)
+        const error = signal(false)
+        const { container } = render(ReactiveValueWithoutDefault({
+          loading,
+          error
+        }))
+
+        expect(container.innerHTML).toBe('<div><i>Loading</i></div>')
+
+        loading(false)
+
+        expect(container.innerHTML).toBe('<div></div>')
+      })
+
+      it('should hand the case its own value, still a signal', () => {
+        const post = signal<{ title: string } | null>(null)
+        const { container } = render(CaseValue({
+          post
+        }))
+
+        expect(container.innerHTML).toBe('<div>No post</div>')
+
+        post({
+          title: 'one'
+        })
+
+        expect(container.innerHTML).toBe('<div><b>one</b></div>')
+
+        // The branch took the signal, not the value: a change to the post
+        // updates the text and leaves the branch where it is
+        const node = container.querySelector('b')
+
+        post({
+          title: 'two'
+        })
+
+        expect(container.innerHTML).toBe('<div><b>two</b></div>')
+        expect(container.querySelector('b')).toBe(node)
+      })
+
+      it('should not read a case below the one that holds', () => {
+        const loading = signal(true)
+        const error = vi.fn(() => false)
+        const { container } = render(ReactiveValue({
+          loading,
+          error
+        }))
+
+        expect(container.innerHTML).toBe('<div><i>Loading</i></div>')
+        expect(error).not.toHaveBeenCalled()
+
+        loading(false)
+
+        expect(error).toHaveBeenCalled()
+      })
+
+      it('should walk the cases once when they move together in a batch', () => {
+        const loading = signal(true)
+        const failed = signal(false)
+        // The case is read once per walk, so the calls count the walks
+        const error = vi.fn(() => failed())
+        const { container } = render(ReactiveValue({
+          loading,
+          error
+        }))
+
+        expect(container.innerHTML).toBe('<div><i>Loading</i></div>')
+
+        batch(() => {
+          loading(false)
+          failed(true)
+        })
+
+        expect(container.innerHTML).toBe('<div><b>Error</b></div>')
+        expect(error).toHaveBeenCalledOnce()
+      })
+
+      it('should walk the cases twice when they move one after another', () => {
+        const loading = signal(true)
+        const failed = signal(false)
+        const error = vi.fn(() => failed())
+        const { container } = render(ReactiveValue({
+          loading,
+          error
+        }))
+
+        loading(false)
+
+        // Without a batch the block settles on the default in between, and
+        // that frame is what a `batch` around the pair hides
+        expect(container.innerHTML).toBe('<div>Ready</div>')
+
+        failed(true)
+
+        expect(container.innerHTML).toBe('<div><b>Error</b></div>')
+        expect(error).toHaveBeenCalledTimes(2)
+      })
+
+      it('should answer with the first default_ when there is more than one', () => {
+        const { container } = render(() => match_(
+          when_(false, () => b()('no')),
+          default_(() => 'first'),
+          default_(() => 'second')
+        ))
+
+        expect(container.innerHTML).toBe('<div>first</div>')
+      })
+    })
+  })
+})

--- a/packages/nanoviews/src/flow/match.stories.ts
+++ b/packages/nanoviews/src/flow/match.stories.ts
@@ -1,0 +1,76 @@
+import type { Signalish } from 'kida'
+import {
+  type Meta,
+  type StoryObj,
+  nanoStory
+} from '@nanoviews/storybook'
+import {
+  b,
+  i
+} from '../elements/elements.js'
+import { default_ } from './switch.js'
+import {
+  when_,
+  match_
+} from './match.js'
+
+// The cases are `Signalish` so a story can take a plain accessor too: that is
+// what a test counts the walks with
+const meta: Meta<{
+  loading: Signalish<boolean>
+  error: Signalish<boolean>
+  post: { title: string } | null
+}> = {
+  title: 'Logic/match_'
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const StaticValue: Story = {
+  render: nanoStory(() => match_(
+    when_(0, () => b()('Zero')),
+    when_('ready', () => b()('Ready')),
+    default_(() => 'Nothing')
+  ))
+}
+
+export const ReactiveValue: Story = {
+  args: {
+    loading: true,
+    error: false
+  },
+  render: nanoStory(({
+    loading,
+    error
+  }) => match_(
+    when_(loading, () => i()('Loading')),
+    when_(error, () => b()('Error')),
+    default_(() => 'Ready')
+  ))
+}
+
+export const ReactiveValueWithoutDefault: Story = {
+  args: {
+    loading: true,
+    error: false
+  },
+  render: nanoStory(({
+    loading,
+    error
+  }) => match_(
+    when_(loading, () => i()('Loading')),
+    when_(error, () => b()('Error'))
+  ))
+}
+
+export const CaseValue: Story = {
+  args: {
+    post: null
+  },
+  render: nanoStory(({ post }) => match_(
+    when_(post, $post => b()(() => $post().title)),
+    default_(() => 'No post')
+  ))
+}

--- a/packages/nanoviews/src/flow/match.ts
+++ b/packages/nanoviews/src/flow/match.ts
@@ -1,0 +1,54 @@
+import {
+  $get,
+  computed
+} from 'kida'
+import type {
+  TruthySignalish,
+  Child
+} from '../internals/index.js'
+import { swap_ } from './swap.js'
+import { default_ } from './switch.js'
+
+export type MatchCase<T> = readonly [T, (value: TruthySignalish<T>) => Child]
+
+// oxlint-disable-next-line typescript/no-explicit-any
+export type AnyMatchCase = MatchCase<any>
+
+/**
+ * Case of `match_`: a value to test and the child to render when it holds
+ * @param $value - Static value or store
+ * @param then_ - Function that returns child when the value is truthy
+ * @returns Case to pass to `match_`
+ */
+export function when_<T>(
+  $value: T,
+  then_: (value: TruthySignalish<T>) => Child
+): MatchCase<T> {
+  return [$value, then_]
+}
+
+/**
+ * Render the child of the first case that holds. A cascade of conditions
+ * written as a list instead of `if_` inside `if_` inside `if_`.
+ *
+ * The list is fixed when the block is built, and the first `default_` in it
+ * is the one that answers. Cases that move together are worth a `batch`:
+ * without one every write swaps the content, and the frame in between shows.
+ * @param cases - Cases to decide from
+ * @returns Block that renders the child of the case that holds
+ */
+export function match_(...cases: AnyMatchCase[]) {
+  const fallback = cases.find(matchCase => matchCase[0] === default_)
+
+  return swap_(
+    // The walk stops at the case that holds, so the block reads the values
+    // above it and no further: a case below the one that won is never asked,
+    // and never wakes the block when it changes. `find` costs a call per case
+    // over a hand-written loop - nanoseconds on a walk that happens when a
+    // value changes, against bytes every consumer carries
+    computed(() => cases.find(
+      matchCase => matchCase[0] !== default_ && $get(matchCase[0])
+    ) || fallback),
+    matched => matched?.[1](matched[0])
+  )
+}


### PR DESCRIPTION
A screen that waits, then fails, then has something to show is three conditions deep, and `if_` nests to say it:

```ts
if_($loading)(
  () => i()('Loading'),
  () => if_($error)(
    $error => b()($error),
    () => article()($post.$title)
  )
)
```

The last branch reads at the bottom of a staircase built out of the two before it, and adding a fourth state moves everything.

`match_` takes the same cascade as a list:

```ts
match_(
  when_($loading, () => i()('Loading')),
  when_($error, $error => b()($error)),
  when_($post, $post => article()($post.$title)),
  default_(() => 'Nothing to show')
)
```

The first case whose value is truthy renders; `default_` answers when none do and may stand anywhere in the list.

### What `when_` hands the branch

The branch gets the case's **signal**, narrowed through `TruthySignalish` — the same contract `if_` gives its `then_`. Not the value: a branch that took the value would depend on it, and every change inside would rebuild the whole subtree instead of updating the text node that changed. There is a test for exactly that — the post's title changes and the `<b>` node stays the same object.

### One computed, and what it buys

```ts
export function match_(...cases: AnyMatchCase[]) {
  const fallback = cases.find(matchCase => matchCase[0] === default_)

  return swap_(
    computed(() => cases.find(
      matchCase => matchCase[0] !== default_ && $get(matchCase[0])
    ) || fallback),
    matched => matched?.[1](matched[0])
  )
}
```

The computed returns the winning case, and `swap_` swaps content when that changes. The case tuple is built once, so its identity is the memo key: while the same case keeps winning, a change to its value updates the branch in place and never rebuilds it. That gate — `oldValue !== (value = compute())` — is what a computed has and an effect does not, which is why the walk cannot simply live inside the swapper.

The walk stops at the case that holds, so the block reads the values above the winner and no further. **A case below the one that won is never asked, and never wakes the block when it changes** — laziness that falls out of the early exit rather than being arranged.

### Measured

The shape was reviewed against the alternatives — an index instead of the tuple (+11 B, same mechanics), no computed at all (breaks the in-place update), nested `if_` (N computeds and N swap blocks), `selector` (a derivative of one source, and there are N here). All heavier; the current form stands.

`find` over a hand-written loop costs a call per case — 5 ns per walk across 2, 4 and 8 cases — and saves 21 B gzip. The walk runs when a value changes, so the bytes win by the house rule; the trade-off is written down at the call site in case a profile ever says otherwise.

Cost: **+79 B gzip** (7581 → 7660), one pin moves, `All publics (Gzip)` 7.6 → 7.7 kB.

### Tests

Four stories under `Logic/match_` and eight tests written through them, the way `if_` and `switch_` are: the cascade with and without a default, the branch keeping its node while the value changes, a case below the winner staying unread, and the pair that documents `batch` — the cases moving together walk once, the same cases moving one after another walk twice and show the frame in between.

Lint, `tsc --noEmit` and 139 tests are green.
