### PR TITLE
fix(kida): keep a `resolved` factory unstarted until the first read

### DIFF
--- a/packages/kida/src/resolved.spec.ts
+++ b/packages/kida/src/resolved.spec.ts
@@ -44,6 +44,30 @@ describe('kida', () => {
       expect(accessor).toHaveBeenCalledTimes(1)
     })
 
+    it('should resolve with the direct promise', async () => {
+      const promise = Promise.resolve(42)
+      const [$result, $error, $pending] = resolved(promise)
+
+      expect($result()).toBeUndefined()
+      expect($error()).toBeUndefined()
+      expect($pending()).toBe(true)
+
+      await promise
+
+      expect($result()).toBe(42)
+      expect($error()).toBeUndefined()
+      expect($pending()).toBe(false)
+    })
+
+    it('should not call the accessor until the first read', () => {
+      const accessor = vi.fn(() => Promise.resolve(42))
+      const [, , $pending] = resolved(accessor)
+
+      expect(accessor).not.toHaveBeenCalled()
+      expect($pending()).toBe(true)
+      expect(accessor).toHaveBeenCalledTimes(1)
+    })
+
     it('should resolve with the static value', () => {
       const [$result, $error, $pending] = resolved(42)
 

--- a/packages/kida/src/resolved.ts
+++ b/packages/kida/src/resolved.ts
@@ -2,7 +2,8 @@ import {
   type Accessor,
   type ReadableSignal,
   signal,
-  computed
+  computed,
+  untracked
 } from 'agera'
 import type { FalsyValue } from './types.js'
 import { toSignal } from './utils.js'
@@ -91,7 +92,9 @@ export function resolved<T>(
     return $state()
   }
 
-  resolve()
+  if (promise instanceof Promise) {
+    untracked(resolve)
+  }
 
   return [
     computed(() => resolve().data),


### PR DESCRIPTION
Before this, `resolved(() => fetch(...))` fired the request at the moment of the call: the eager `resolve()` read the accessor the author explicitly wrapped into a function, and the read was tracked, so an enclosing computed linked the wrapper as a dependency and re-evaluated on its settles.

Now a factory stays untouched until the state is first read. A promise handed in directly is still resolved at creation — it is already in flight, and the eager subscription keeps its rejection handled — but under `untracked`.

Two new tests pin it down: a direct promise resolves as before, a factory is not called until the first read.

Lint, `tsc --noEmit`, 69 kida tests and size-limit are green; the pins hold.