### PR TITLE
feat(kida)!: attach the `resolved` promise as a task and hand values through verbatim

### DIFF
--- a/packages/kida/.size-limit.json
+++ b/packages/kida/.size-limit.json
@@ -4,13 +4,13 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "5.05 kB"
+    "limit": "5 kB"
   },
   {
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "4.7 kB"
+    "limit": "4.65 kB"
   },
   {
     "name": "Signal (Gzip)",

--- a/packages/kida/src/resolved.spec.ts
+++ b/packages/kida/src/resolved.spec.ts
@@ -8,6 +8,7 @@ import {
   signal,
   computed
 } from 'agera'
+import { waitTasks } from './tasks.js'
 import { resolved } from './resolved.js'
 
 describe('kida', () => {
@@ -68,10 +69,28 @@ describe('kida', () => {
       expect(accessor).toHaveBeenCalledTimes(1)
     })
 
+    it('should attach the promise as a task to the state', async () => {
+      const [$result] = resolved(() => Promise.resolve(42))
+
+      expect($result()).toBeUndefined()
+
+      await waitTasks($result)
+
+      expect($result()).toBe(42)
+    })
+
     it('should resolve with the static value', () => {
       const [$result, $error, $pending] = resolved(42)
 
       expect($result()).toBe(42)
+      expect($error()).toBeUndefined()
+      expect($pending()).toBe(false)
+    })
+
+    it('should resolve with the static falsy value', () => {
+      const [$result, $error, $pending] = resolved(0)
+
+      expect($result()).toBe(0)
       expect($error()).toBeUndefined()
       expect($pending()).toBe(false)
     })
@@ -107,13 +126,13 @@ describe('kida', () => {
       const $promise = signal<number | Promise<number> | null>(promise)
       const [$result, , $pending] = resolved($promise)
 
-      expect($result()).toBeUndefined()
+      expect($result()).toBeNull()
       expect($pending()).toBe(false)
 
       promise = Promise.resolve(1)
       $promise(promise)
 
-      expect($result()).toBeUndefined()
+      expect($result()).toBeNull()
       expect($pending()).toBe(true)
 
       await promise
@@ -134,7 +153,7 @@ describe('kida', () => {
 
       $promise(null)
 
-      expect($result()).toBeUndefined()
+      expect($result()).toBeNull()
       expect($pending()).toBe(false)
 
       $promise(42)

--- a/packages/kida/src/resolved.ts
+++ b/packages/kida/src/resolved.ts
@@ -5,7 +5,7 @@ import {
   computed,
   untracked
 } from 'agera'
-import type { FalsyValue } from './types.js'
+import { task } from './tasks.js'
 import { toSignal } from './utils.js'
 
 export type Resolved<T> = readonly [
@@ -16,18 +16,6 @@ export type Resolved<T> = readonly [
 
 export type ResolvedLike<T> = readonly [...Resolved<T>, ...unknown[]]
 
-interface ResolvedState<T> {
-  data: T | undefined
-  error: unknown
-  pending: boolean
-}
-
-const INITIAL_STATE = {
-  data: undefined,
-  error: undefined,
-  pending: false
-}
-
 /**
  * Resolve a promise accessor into result, error, and pending signals.
  * When the source promise changes, stale data is preserved while the new
@@ -37,56 +25,46 @@ const INITIAL_STATE = {
  */
 /* @__NO_SIDE_EFFECTS__ */
 export function resolved<T>(
-  promise: Accessor<T | Promise<T> | FalsyValue> | T | Promise<T> | FalsyValue
+  promise: Accessor<T | Promise<T>> | T | Promise<T>
 ): Resolved<T> {
-  let currentPromise: T | Promise<T> | FalsyValue = null
+  let currentPromise: T | Promise<T> | undefined
+  let data: T | undefined
+  let error: unknown
   const $promise = toSignal(promise)
-  const $state = signal<ResolvedState<T>>(INITIAL_STATE)
+  // The pending flag doubles as the task target and the only notifier:
+  // `data` and `error` live in the closure and may only change together
+  // with a `$state` write or a `$promise` change
+  const $state = signal(false)
   const resolve = () => {
-    const promise = $promise() as T | Promise<T> | FalsyValue
+    const value = $promise() as T | Promise<T>
 
-    if (currentPromise === promise) {
-      return $state()
-    }
+    if (currentPromise !== value) {
+      currentPromise = value
+      error = undefined
 
-    currentPromise = promise
+      if (value instanceof Promise) {
+        $state(true)
 
-    if (!promise) {
-      $state(INITIAL_STATE)
-      return $state()
-    }
-
-    if (promise instanceof Promise) {
-      $state(state => ({
-        ...state,
-        error: undefined,
-        pending: true
-      }))
-
-      promise.then(
-        (data) => {
-          if (currentPromise === promise) {
-            $state({
-              ...INITIAL_STATE,
-              data
-            })
+        // The pool holds the writer chain, so a wait wakes up strictly
+        // after the state is written
+        void task($state, value.then(
+          (nextData) => {
+            if (currentPromise === value) {
+              data = nextData
+              $state(false)
+            }
+          },
+          (nextError) => {
+            if (currentPromise === value) {
+              error = nextError
+              $state(false)
+            }
           }
-        },
-        (error) => {
-          if (currentPromise === promise) {
-            $state(state => ({
-              ...state,
-              error,
-              pending: false
-            }))
-          }
-        }
-      )
-    } else {
-      $state({
-        ...INITIAL_STATE,
-        data: promise
-      })
+        ))
+      } else {
+        data = value
+        $state(false)
+      }
     }
 
     return $state()
@@ -97,8 +75,8 @@ export function resolved<T>(
   }
 
   return [
-    computed(() => resolve().data),
-    computed(() => resolve().error),
-    computed(() => resolve().pending)
+    computed(() => (resolve(), data)),
+    computed(() => (resolve(), error)),
+    computed(resolve)
   ] as const
 }

--- a/packages/store/.size-limit.json
+++ b/packages/store/.size-limit.json
@@ -4,7 +4,7 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "6.45 kB"
+    "limit": "6.4 kB"
   },
   {
     "name": "All publics (Brotli)",


### PR DESCRIPTION
Stacked on #222 — the last consumer of the old pool story: `resolved` now plugs into per-signal tasks and sheds both its state object and its falsy special-casing.

The promise is attached as a task to the state signal the moment `resolve` takes it in — for a lazy factory that is the first read, exactly when a streaming renderer wakes the accessor — and the pool holds the writer chain, so a wait wakes up strictly after the state is written, by construction rather than by reaction order. `waitTasks` of any of the three outputs awaits the value; a spec pins it.

The state object collapsed into a boolean pending flag that doubles as the task target and the only notifier, with `data` and `error` living in the closure and written before the flag flips — no torn snapshots, verified by an effect trace. `INITIAL_STATE` and every object spread went with it: 50 B gzip off kida (4909 → 4853), and the pins step down twice — kida 4.95 → 4.9 gzip and 4.55 → 4.5 brotli, store 6.3 → 6.25 and 5.8 → 5.75 in tow. The shape came out of a three-way review round (two Claude agents and Codex on a size-limit-faithful pipeline); the runner-ups and the rejected forms (three separate signals, `.map` wrappers, merged `then` branches) lost either bytes or atomicity.

The breaking part is the contract fix: `resolved` hands values through verbatim. A falsy source value is data — `resolved(0)` yields `0`, `false` yields `false` — not a silent reset to `undefined`; emptiness is expressed by `T` itself (`resolved<User | null>(() => $id() ? fetchUser($id()) : null)`), and the input type drops the falsy arm. Stale-while-pending, the `currentPromise` guard, the eager untracked resolve for a bare promise and the laziness of a factory are untouched.

Lint, `tsc --noEmit`, 79 kida and 55 store tests, and size-limit across the chain are green.