### PR TITLE
feat(agera,nanoviews): add `show_` with pausable effect scopes

### DIFF
--- a/packages/agera/.size-limit.json
+++ b/packages/agera/.size-limit.json
@@ -4,13 +4,13 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "3.15 kB"
+    "limit": "3.3 kB"
   },
   {
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "2.9 kB"
+    "limit": "3.05 kB"
   },
   {
     "name": "Signal (Gzip)",

--- a/packages/agera/src/effect.spec.ts
+++ b/packages/agera/src/effect.spec.ts
@@ -19,6 +19,8 @@ import {
   boundDeferScope,
   startScope,
   stopScope,
+  pauseScope,
+  resumeScope,
   observe,
   isMounted
 } from './index.js'
@@ -2231,6 +2233,303 @@ describe('agera', () => {
 
       src(1)
       expect(c()).toBe(0)
+    })
+  })
+
+  describe('pauseScope', () => {
+    it('should pause effects and warm them back up on resume', () => {
+      const $value = signal(1)
+      const log: string[] = []
+      const scope = deferScope(() => {
+        effect(() => {
+          log.push(`value ${$value()}`)
+
+          return () => log.push('cleanup')
+        })
+      })
+
+      startScope(scope)
+
+      expect(log).toEqual(['value 1'])
+
+      $value(2)
+
+      expect(log).toEqual(['value 1', 'cleanup', 'value 2'])
+      log.length = 0
+
+      pauseScope(scope)
+
+      expect(log).toEqual(['cleanup'])
+      log.length = 0
+
+      $value(3)
+
+      expect(log).toEqual([])
+
+      resumeScope(scope)
+
+      expect(log).toEqual(['value 3'])
+      log.length = 0
+
+      $value(4)
+
+      expect(log).toEqual(['cleanup', 'value 4'])
+
+      stopScope(scope)
+    })
+
+    it('should keep `noDefer` effects running while paused', () => {
+      const $value = signal(1)
+      const log: string[] = []
+      const scope = deferScope(() => {
+        effect(() => {
+          log.push(`deferred ${$value()}`)
+        })
+        effect(() => {
+          log.push(`live ${$value()}`)
+        }, true)
+      })
+
+      startScope(scope)
+      log.length = 0
+      pauseScope(scope)
+
+      $value(2)
+
+      expect(log).toEqual(['live 2'])
+
+      resumeScope(scope)
+
+      expect(log).toEqual(['live 2', 'deferred 2'])
+
+      stopScope(scope)
+    })
+
+    it('should hold a scope paused before its first start back from the parent start', () => {
+      const log: string[] = []
+      let inner!: DeferredScope
+      const scope = deferScope(() => {
+        effect(() => {
+          log.push('outer')
+        })
+
+        inner = boundDeferScope()(() => {
+          effect(() => {
+            log.push('inner')
+          })
+        })
+
+        pauseScope(inner)
+      })
+
+      startScope(scope)
+
+      expect(log).toEqual(['outer'])
+
+      startScope(inner)
+
+      expect(log).toEqual(['outer', 'inner'])
+
+      stopScope(scope)
+    })
+
+    it('should keep a self-paused nested scope down across an outer pause and resume', () => {
+      const $value = signal(1)
+      const log: string[] = []
+      let inner!: DeferredScope
+      const scope = deferScope(() => {
+        effect(() => {
+          log.push(`outer ${$value()}`)
+        })
+
+        inner = boundDeferScope()(() => {
+          effect(() => {
+            log.push(`inner ${$value()}`)
+          })
+        })
+      })
+
+      startScope(scope)
+
+      expect(log).toEqual(['inner 1', 'outer 1'])
+
+      pauseScope(inner)
+      pauseScope(scope)
+      log.length = 0
+      $value(2)
+      resumeScope(scope)
+
+      expect(log).toEqual(['outer 2'])
+
+      resumeScope(inner)
+
+      expect(log).toEqual(['outer 2', 'inner 2'])
+
+      stopScope(scope)
+    })
+
+    it('should stop a paused scope without doubling cleanups', () => {
+      const log: string[] = []
+      const scope = deferScope(() => {
+        effect(() => {
+          log.push('run')
+
+          return () => log.push('cleanup')
+        })
+      })
+
+      startScope(scope)
+      pauseScope(scope)
+
+      expect(log).toEqual(['run', 'cleanup'])
+
+      stopScope(scope)
+      startScope(scope)
+
+      expect(log).toEqual(['run', 'cleanup'])
+    })
+
+    it('should leave signals and computeds captured by the scope body untouched', () => {
+      const $value = signal(1)
+      const $double = computed(() => $value() * 2)
+      const log: (string | number)[] = []
+      const scope = deferScope(() => {
+        log.push($value(), $double())
+
+        effect(() => {
+          log.push(`effect ${$value()}`)
+        })
+      })
+
+      startScope(scope)
+      pauseScope(scope)
+      resumeScope(scope)
+
+      expect(log).toEqual([1, 2, 'effect 1', 'effect 1'])
+
+      $value(2)
+
+      expect($double()).toBe(4)
+      expect(log).toEqual([1, 2, 'effect 1', 'effect 1', 'effect 2'])
+
+      stopScope(scope)
+    })
+
+    it('should consume the cleanup of an effect that paused its own scope mid-run', () => {
+      const $value = signal(0)
+      const log: string[] = []
+      let hide = true
+      // oxlint-disable-next-line no-use-before-define
+      const scope = deferScope(() => {
+        effect(() => {
+          log.push(`run ${$value()}`)
+
+          if (hide && $value() === 1) {
+            hide = false
+            pauseScope(scope)
+          }
+
+          return () => log.push('cleanup')
+        })
+      })
+
+      startScope(scope)
+
+      expect(log).toEqual(['run 0'])
+      log.length = 0
+
+      $value(1)
+
+      expect(log).toEqual(['cleanup', 'run 1'])
+      log.length = 0
+
+      $value(2)
+
+      expect(log).toEqual([])
+
+      resumeScope(scope)
+
+      expect(log).toEqual(['cleanup', 'run 2'])
+
+      stopScope(scope)
+    })
+
+    it('should step over an effect stopped by a sibling warmed up in the resume walk', () => {
+      const log: string[] = []
+      let kill = false
+      let stopSecond!: () => void
+      const scope = deferScope(() => {
+        effect(() => {
+          log.push('first')
+
+          if (kill) {
+            stopSecond()
+          }
+        })
+
+        stopSecond = effect(() => {
+          log.push('second')
+        })
+      })
+
+      startScope(scope)
+
+      expect(log).toEqual(['first', 'second'])
+
+      pauseScope(scope)
+      kill = true
+      log.length = 0
+      resumeScope(scope)
+
+      expect(log).toEqual(['first'])
+
+      stopScope(scope)
+    })
+
+    it('should drop a queued re-run on pause and sync once on resume', () => {
+      const $value = signal(0)
+      const log: number[] = []
+      const scope = deferScope(() => {
+        effect(() => {
+          log.push($value())
+        })
+      })
+
+      startScope(scope)
+      log.length = 0
+
+      batch(() => {
+        $value(1)
+        pauseScope(scope)
+      })
+
+      expect(log).toEqual([])
+
+      $value(2)
+
+      expect(log).toEqual([])
+
+      resumeScope(scope)
+
+      expect(log).toEqual([2])
+
+      stopScope(scope)
+    })
+
+    it('should ignore pause of a stopped scope', () => {
+      const log: string[] = []
+      const scope = deferScope(() => {
+        effect(() => {
+          log.push('run')
+        })
+      })
+
+      startScope(scope)
+      stopScope(scope)
+      pauseScope(scope)
+      startScope(scope)
+
+      expect(log).toEqual(['run'])
     })
   })
 })

--- a/packages/agera/src/effect.ts
+++ b/packages/agera/src/effect.ts
@@ -10,6 +10,8 @@ import {
   boundDeferScope,
   startScope,
   stopScope,
+  pauseScope,
+  resumeScope,
   pushActiveSub,
   popActiveSub
 } from './internals/system.js'
@@ -20,7 +22,9 @@ export {
   effectScope,
   deferScope,
   startScope,
-  stopScope
+  stopScope,
+  pauseScope,
+  resumeScope
 }
 
 /**

--- a/packages/agera/src/internals/flags.ts
+++ b/packages/agera/src/internals/flags.ts
@@ -22,4 +22,8 @@ export const WritableMode = 1 << 2
 
 export const MountableMode = 1 << 3
 
-export const ExternalModesBase = 4
+export const PausedMode = 1 << 4
+
+export const DeferredMode = 1 << 5
+
+export const ExternalModesBase = 6

--- a/packages/agera/src/internals/system.ts
+++ b/packages/agera/src/internals/system.ts
@@ -29,7 +29,9 @@ import {
   ScopeMode,
   WritableMode,
   MountableMode,
-  LazyMode
+  LazyMode,
+  PausedMode,
+  DeferredMode
 } from './flags.js'
 
 // #region Lifecycle sockets
@@ -536,7 +538,10 @@ export function effect(fn: EffectCallback, noDefer?: boolean, lcx?: ReactiveNode
     link(e, activeSub, 0)
 
     if (!noDefer && activeSub.modes & LazyMode) {
-      e.modes |= LazyMode
+      // The deferral mark outlives the token: a pause walk takes what was
+      // deferred and leaves everything else - `noDefer` effects among it -
+      // running, so a hidden subtree stays reachable through them
+      e.modes = LazyMode | DeferredMode
       return effectOper.bind(e)
     }
   }
@@ -1072,11 +1077,14 @@ export function selector<T, U = T, R = boolean>(
 //
 // A deferred scope is an ordinary effect scope whose effects are captured
 // but not warmed up: `deferScope` runs the body, `startScope` releases it,
-// `stopScope` discards it. The layer introduces no node kind and no new
-// field - the whole state machine is one mode bit on a scope node:
+// `pauseScope` puts it down keeping the nodes, `resumeScope` warms them
+// back up, `stopScope` discards it. The layer introduces no node kind and
+// no new field - the whole state machine is two mode bits on a scope node:
 //
 //   LazyMode set     LAZY      body ran, nothing was warmed up yet
+//   + PausedMode     HELD      stays lazy across the parent start
 //   LazyMode clear   STARTED   effects are live      (flags & MutableFlag)
+//   + PausedMode     PAUSED    effects hold pause tokens
 //   LazyMode clear   STOPPED   effects are gone      (flags === NoneFlag)
 //
 // LAW 1 - LazyMode is a one-shot token.
@@ -1181,28 +1189,31 @@ function startDeferred(e: ReactiveNode): void {
     let own: Link | undefined = deps
 
     // Nested scopes claim their token and release their own capture list
-    // first, so an effect body below observes a subtree that is already live
+    // first, so an effect body below observes a subtree that is already
+    // live. A paused scope keeps its token: it starts only by its own
+    // explicit `startScope`
     do {
       const dep = nested.dep
 
       nested = nested.nextDep
 
-      if ((dep.modes & (LazyMode | ScopeMode)) === (LazyMode | ScopeMode)) {
+      if ((dep.modes & (LazyMode | ScopeMode | PausedMode)) === (LazyMode | ScopeMode)) {
         dep.modes &= ~LazyMode
         startDeferred(dep)
       }
     } while (nested !== undefined)
 
-    // Then the effects captured directly here. Whatever still holds a token
-    // is an effect: nested scopes were spent by the pass above, and anything
-    // stopped meanwhile - by a sibling warmed up in this very walk - was
-    // spent by the stop and is stepped over instead of being resurrected
+    // Then the effects captured directly here. Whatever still holds a bare
+    // token is an effect: nested scopes were spent by the pass above or
+    // skipped with their pause mark on, and anything stopped meanwhile - by
+    // a sibling warmed up in this very walk - was spent by the stop and is
+    // stepped over instead of being resurrected
     do {
       const dep = own.dep
 
       own = own.nextDep
 
-      if (dep.modes & LazyMode) {
+      if ((dep.modes & (LazyMode | PausedMode)) === LazyMode) {
         dep.modes &= ~LazyMode
         warmupEffect(dep as EffectNode)
       }
@@ -1231,7 +1242,7 @@ export function startScope(scope: DeferredScope): DeferredScope {
       || !(parent.modes & LazyMode) && parent.flags & MutableFlag
     )
   ) {
-    e.modes &= ~LazyMode
+    e.modes &= ~(LazyMode | PausedMode)
 
     // What the lazy body left pending belongs to this moment - the scope
     // became live now, before any of its deferred effects add more
@@ -1268,6 +1279,135 @@ export function stopScope(scope: DeferredScope): void {
   // The other half - destroying the effects captured directly here - is the
   // `purgeDeps` of the shared STOPPED transition
   effectScopeOper.call(e)
+}
+
+// Pausing is partial where stopping is total: the effect keeps its node and
+// its place under the scope, runs its cleanup, loses its subscriptions and
+// takes a pause token. `startScope` warms the token holders back up, and the
+// re-run of every body is also what syncs work the subtree slept through
+function pauseDeferred(e: ReactiveNode): void {
+  const deps = e.deps
+
+  if (deps !== undefined) {
+    let nested: Link | undefined = deps
+    let own: Link | undefined = deps
+
+    // Nested scopes go first, mirroring the stop walk: a cleanup below runs
+    // over a subtree that is already parked. A self-paused scope already
+    // holds its subtree, a lazy one never started it
+    do {
+      const dep = nested.dep
+
+      nested = nested.nextDep
+
+      if ((dep.modes & (ScopeMode | PausedMode | LazyMode)) === ScopeMode) {
+        pauseDeferred(dep)
+      }
+    } while (nested !== undefined)
+
+    // Then the effects captured directly here: exactly the ones that were
+    // deferred at creation take the pause token, so signals and computeds
+    // captured by a read in the scope body, `noDefer` effects - a hidden
+    // subtree is kept reachable through them - and anything stopped
+    // meanwhile stay untouched
+    do {
+      const dep = own.dep
+
+      own = own.nextDep
+
+      if (
+        (dep.modes & (PausedMode | LazyMode | DeferredMode)) === DeferredMode
+        && dep.flags
+      ) {
+        destroyEffect(dep)
+        dep.depsTail = undefined
+        dep.flags = WatchingFlag | RecursedCheckFlag
+        dep.modes |= PausedMode
+        purgeDeps(dep)
+      }
+    } while (own !== undefined)
+  }
+}
+
+function resumeDeferred(e: ReactiveNode): void {
+  const deps = e.deps
+
+  if (deps !== undefined) {
+    let nested: Link | undefined = deps
+    let own: Link | undefined = deps
+
+    // The mirror image of the start walk: own effects warm up FIRST. An
+    // effect that controls a sibling scope re-checks its world stale from
+    // the sleep and pauses the scope before the pass below could wake it -
+    // this is what keeps a subtree hidden during the sleep from a single
+    // transient run. An effect stopped meanwhile - by a sibling warmed up
+    // in this very walk - keeps its spent token and is stepped over
+    do {
+      const dep = own.dep
+
+      own = own.nextDep
+
+      if ((dep.modes & (ScopeMode | PausedMode)) === PausedMode && dep.flags) {
+        dep.modes &= ~PausedMode
+        // A body that paused its own effect mid-run left a fresh cleanup
+        // behind - consume it before the warmup makes a new one
+        destroyEffect(dep)
+        warmupEffect(dep as EffectNode)
+      }
+    } while (own !== undefined)
+
+    // Then the nested scopes. A scope holding its own pause token stays
+    // down, a lazy one stays unstarted
+    do {
+      const dep = nested.dep
+
+      nested = nested.nextDep
+
+      if ((dep.modes & (ScopeMode | PausedMode | LazyMode)) === ScopeMode) {
+        resumeDeferred(dep)
+      }
+    } while (nested !== undefined)
+  }
+}
+
+/**
+ * Pause the scope: destroy nothing, run effect cleanups, drop their
+ * subscriptions and keep the nodes for `resumeScope` to warm back up.
+ * `noDefer` effects keep running. A nested scope paused on its own stays
+ * paused across an outer pause and resume, and a lazy scope paused before
+ * its first start does not start with its parent.
+ * @internal
+ * @param scope - Deferred scope handle.
+ */
+export function pauseScope(scope: DeferredScope): void {
+  const e = scope as unknown as ReactiveNode
+
+  // A lazy scope has nothing running yet, and a paused one is already
+  // down: for them the mark alone holds the position
+  if (!(e.modes & (PausedMode | LazyMode))) {
+    pauseDeferred(e)
+    lifecycleSettle?.()
+  }
+
+  e.modes |= PausedMode
+}
+
+/**
+ * Warm the paused effects of the scope back up. The re-run of every body is
+ * also what syncs the work the subtree slept through. The caller resumes
+ * from a live position: a scope paused before its first start is started
+ * with `startScope` instead.
+ * @internal
+ * @param scope - Deferred scope handle.
+ */
+export function resumeScope(scope: DeferredScope): void {
+  const e = scope as unknown as ReactiveNode
+
+  if (e.modes & PausedMode) {
+    e.modes &= ~PausedMode
+    lifecycleSettle?.()
+    resumeDeferred(e)
+  }
 }
 
 /**

--- a/packages/kida/.size-limit.json
+++ b/packages/kida/.size-limit.json
@@ -4,13 +4,13 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "4.95 kB"
+    "limit": "5.1 kB"
   },
   {
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "4.6 kB"
+    "limit": "4.7 kB"
   },
   {
     "name": "Signal (Gzip)",

--- a/packages/nanoviews/.size-limit.json
+++ b/packages/nanoviews/.size-limit.json
@@ -4,13 +4,13 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "7.7 kB"
+    "limit": "7.9 kB"
   },
   {
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "6.8 kB"
+    "limit": "7.05 kB"
   },
   {
     "name": "Average usage (Gzip)",

--- a/packages/nanoviews/src/flow/index.ts
+++ b/packages/nanoviews/src/flow/index.ts
@@ -1,4 +1,5 @@
 export * from './swap.js'
+export * from './show.js'
 export * from './if.js'
 export * from './switch.js'
 export * from './match.js'

--- a/packages/nanoviews/src/flow/show.spec.ts
+++ b/packages/nanoviews/src/flow/show.spec.ts
@@ -1,0 +1,104 @@
+import {
+  describe,
+  it,
+  expect,
+  vi
+} from 'vitest'
+import { composeStories } from '@nanoviews/storybook'
+import {
+  render,
+  fireEvent
+} from '@nanoviews/testing-library'
+import { signal } from 'kida'
+import { b } from '../elements/elements.js'
+import * as Stories from './show.stories.js'
+import { show_ } from './show.js'
+
+const {
+  StaticValue,
+  ReactiveValue,
+  KeptAlive,
+  Counter
+} = composeStories(Stories)
+
+describe('nanoviews', () => {
+  describe('flow', () => {
+    describe('show', () => {
+      it('should render a static value', () => {
+        const { container } = render(StaticValue())
+
+        expect(container.innerHTML).toBe('<div><b>shown</b></div>')
+      })
+
+      it('should render nothing for a static falsy value without calling render', () => {
+        const render_ = vi.fn(() => b()('never'))
+
+        expect(show_(false, render_)).toBe(null)
+        expect(render_).not.toHaveBeenCalled()
+      })
+
+      it('should show and hide the child', () => {
+        const visible = signal(false)
+        const { container } = render(ReactiveValue({
+          visible
+        }))
+
+        expect(container.innerHTML).toBe('<div></div>')
+
+        visible(true)
+
+        expect(container.innerHTML).toBe('<div><b>content</b></div>')
+
+        visible(false)
+
+        expect(container.innerHTML).toBe('<div></div>')
+      })
+
+      it('should keep the tree alive and up to date across the toggles', () => {
+        const visible = signal(true)
+        const text = signal('a')
+        const { container } = render(KeptAlive({
+          visible,
+          text
+        }))
+        const [node] = container.getElementsByTagName('b')
+
+        expect(container.innerHTML).toBe('<div><b>a</b></div>')
+
+        visible(false)
+        text('b')
+        visible(true)
+
+        // the tree is parked, not destroyed: the same node comes back, and
+        // the binding kept it fresh while it was hidden
+        expect(container.innerHTML).toBe('<div><b>b</b></div>')
+        expect(container.getElementsByTagName('b')[0]).toBe(node)
+      })
+
+      it('should keep the counter state and the click alive across the toggles', () => {
+        const visible = signal(true)
+        const { container } = render(Counter({
+          visible
+        }))
+        const [counter] = container.getElementsByTagName('button')
+
+        fireEvent.click(counter)
+
+        expect(container.innerHTML).toBe('<div><button>Count: 1</button></div>')
+
+        visible(false)
+
+        expect(container.innerHTML).toBe('<div></div>')
+
+        visible(true)
+
+        expect(container.getElementsByTagName('button')[0]).toBe(counter)
+        expect(container.innerHTML).toBe('<div><button>Count: 1</button></div>')
+
+        fireEvent.click(counter)
+
+        expect(container.innerHTML).toBe('<div><button>Count: 2</button></div>')
+      })
+    })
+  })
+})

--- a/packages/nanoviews/src/flow/show.stories.ts
+++ b/packages/nanoviews/src/flow/show.stories.ts
@@ -1,0 +1,61 @@
+import { signal } from 'kida'
+import {
+  type Meta,
+  type StoryObj,
+  nanoStory
+} from '@nanoviews/storybook'
+import {
+  b,
+  button
+} from '../elements/elements.js'
+import { show_ } from './show.js'
+
+const meta: Meta<{
+  visible: boolean
+  text: string
+}> = {
+  title: 'Logic/show_'
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const StaticValue: Story = {
+  render: nanoStory(() => show_(true, () => b()('shown')))
+}
+
+export const ReactiveValue: Story = {
+  args: {
+    visible: false
+  },
+  render: nanoStory(({ visible }) => show_(visible, () => b()('content')))
+}
+
+// The tree lives across the toggles: hiding parks it instead of destroying,
+// and bindings keep it up to date while it is parked
+export const KeptAlive: Story = {
+  args: {
+    visible: true,
+    text: 'a'
+  },
+  render: nanoStory(({
+    visible,
+    text
+  }) => show_(visible, () => b()(text)))
+}
+
+// Internal state survives the toggles: the count stays and the click keeps
+// working, where `if_` would rebuild the counter from zero
+export const Counter: Story = {
+  args: {
+    visible: true
+  },
+  render: nanoStory(({ visible }) => show_(visible, () => {
+    const $count = signal(0)
+
+    return button({
+      onClick: () => $count($count() + 1)
+    })('Count: ', $count)
+  }))
+}

--- a/packages/nanoviews/src/flow/show.ts
+++ b/packages/nanoviews/src/flow/show.ts
@@ -1,0 +1,24 @@
+import {
+  type Signalish,
+  isAccessor
+} from 'kida'
+import {
+  type Child,
+  show
+} from '../internals/index.js'
+
+/**
+ * Render a child that lives regardless of the value: the tree is built once
+ * and `noDefer` effects keep it up to date, but it stands in the document
+ * with its deferred effects running only while the value is truthy.
+ * @param $value - Static value or store
+ * @param render - Function that returns the child
+ * @returns Block that shows and hides the child
+ */
+export function show_($value: Signalish<unknown>, render: () => Child) {
+  if (isAccessor($value)) {
+    return show($value, render)
+  }
+
+  return $value ? render() : null
+}

--- a/packages/nanoviews/src/flow/swap.spec.ts
+++ b/packages/nanoviews/src/flow/swap.spec.ts
@@ -4,18 +4,28 @@ import {
   expect,
   vi
 } from 'vitest'
+import { composeStories } from '@nanoviews/storybook'
 import { render } from '@nanoviews/testing-library'
 import { signal } from 'kida'
-import {
-  b,
-  i
-} from '../elements/elements.js'
+import { b } from '../elements/elements.js'
+import * as Stories from './swap.stories.js'
 import { swap_ } from './swap.js'
+
+const {
+  StaticValue,
+  ReactiveValue
+} = composeStories(Stories)
 
 describe('nanoviews', () => {
   describe('flow', () => {
     describe('swap', () => {
-      it('should render a static value without subscribing', () => {
+      it('should render a static value', () => {
+        const { container } = render(StaticValue())
+
+        expect(container.innerHTML).toBe('<div><b>static</b></div>')
+      })
+
+      it('should call the render once for a static value without subscribing', () => {
         const render_ = vi.fn((value: string) => b()(value))
         const { container } = render(() => swap_('static', render_))
 
@@ -24,22 +34,21 @@ describe('nanoviews', () => {
       })
 
       it('should build the child anew on every change', () => {
-        const $tab = signal('list')
-        const { container } = render(() => swap_(
-          $tab,
-          tab => (tab === 'list' ? b()(tab) : i()(tab))
-        ))
+        const tab = signal('list')
+        const { container } = render(ReactiveValue({
+          tab
+        }))
         const [first] = container.getElementsByTagName('b')
 
         expect(container.innerHTML).toBe('<div><b>list</b></div>')
 
-        $tab('grid')
+        tab('grid')
 
         expect(container.innerHTML).toBe('<div><i>grid</i></div>')
 
         // the child is rebuilt, not updated: the node the first value made
         // is gone rather than reused
-        $tab('list')
+        tab('list')
 
         expect(container.innerHTML).toBe('<div><b>list</b></div>')
         expect(container.getElementsByTagName('b')[0]).not.toBe(first)

--- a/packages/nanoviews/src/flow/swap.stories.ts
+++ b/packages/nanoviews/src/flow/swap.stories.ts
@@ -1,0 +1,34 @@
+import {
+  type Meta,
+  type StoryObj,
+  nanoStory
+} from '@nanoviews/storybook'
+import {
+  b,
+  i
+} from '../elements/elements.js'
+import { swap_ } from './swap.js'
+
+const meta: Meta<{
+  tab: string
+}> = {
+  title: 'Logic/swap_'
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const StaticValue: Story = {
+  render: nanoStory(() => swap_('static', value => b()(value)))
+}
+
+export const ReactiveValue: Story = {
+  args: {
+    tab: 'list'
+  },
+  render: nanoStory(({ tab }) => swap_(
+    tab,
+    tab => (tab === 'list' ? b()(tab) : i()(tab))
+  ))
+}

--- a/packages/nanoviews/src/internals/elements/child.ts
+++ b/packages/nanoviews/src/internals/elements/child.ts
@@ -104,6 +104,15 @@ export function remove(start: ChildNode, end: Node): void {
   range.deleteContents()
 }
 
+export function extractBetween(start: Node, end: Node): DocumentFragment {
+  const range = document.createRange()
+
+  range.setStartAfter(start)
+  range.setEndBefore(end)
+
+  return range.extractContents()
+}
+
 export function removeBetween(start: Node, end: Node): void {
   const parent = start.parentNode!
 

--- a/packages/nanoviews/src/internals/flow/index.ts
+++ b/packages/nanoviews/src/internals/flow/index.ts
@@ -1,2 +1,3 @@
 export * from './swap.js'
+export * from './show.js'
 export * from './loop.js'

--- a/packages/nanoviews/src/internals/flow/show.spec.ts
+++ b/packages/nanoviews/src/internals/flow/show.spec.ts
@@ -1,0 +1,261 @@
+import {
+  describe,
+  it,
+  expect,
+  vi
+} from 'vitest'
+import { render } from '@nanoviews/testing-library'
+import {
+  signal,
+  effect
+} from 'kida'
+import { createElement } from '../elements/index.js'
+import { show } from './show.js'
+
+describe('nanoviews', () => {
+  describe('internals', () => {
+    describe('flow', () => {
+      describe('show', () => {
+        it('should build the tree hidden and mount it when the value turns truthy', () => {
+          const $visible = signal(false)
+          const $text = signal('a')
+          const renderFn = vi.fn(() => createElement('div')($text))
+          const { container } = render(() => show($visible, renderFn))
+
+          expect(renderFn).toHaveBeenCalledTimes(1)
+          expect(container.innerHTML).toBe('<div></div>')
+
+          $visible(true)
+
+          expect(container.innerHTML).toBe('<div><div>a</div></div>')
+
+          $visible(false)
+
+          expect(container.innerHTML).toBe('<div></div>')
+
+          $visible(true)
+
+          expect(container.innerHTML).toBe('<div><div>a</div></div>')
+          expect(renderFn).toHaveBeenCalledTimes(1)
+        })
+
+        it('should hand the initial truthy tree over in the first pass', () => {
+          const $visible = signal(true)
+          const log: string[] = []
+          const { container } = render(() => {
+            const child = show($visible, () => {
+              effect(() => {
+                log.push('content')
+              })
+
+              return createElement('div')('shown')
+            })
+
+            effect(() => {
+              log.push('after')
+            })
+
+            return child
+          })
+
+          expect(container.innerHTML).toBe('<div><div>shown</div></div>')
+          expect(log).toEqual(['content', 'after'])
+
+          $visible(false)
+
+          expect(container.innerHTML).toBe('<div></div>')
+
+          $visible(true)
+
+          expect(container.innerHTML).toBe('<div><div>shown</div></div>')
+        })
+
+        it('should keep the hidden tree up to date through `noDefer` effects', () => {
+          const $visible = signal(false)
+          const $text = signal('a')
+          const { container } = render(() => show($visible, () => createElement('div')($text)))
+
+          $text('b')
+          $visible(true)
+
+          expect(container.innerHTML).toBe('<div><div>b</div></div>')
+
+          $visible(false)
+          $text('c')
+          $visible(true)
+
+          expect(container.innerHTML).toBe('<div><div>c</div></div>')
+        })
+
+        it('should run deferred effects only while shown and sync them on wake', () => {
+          const $visible = signal(false)
+          const $value = signal(1)
+          const log: string[] = []
+
+          render(() => show($visible, () => {
+            effect(() => {
+              log.push(`deferred ${$value()}`)
+
+              return () => log.push('cleanup')
+            })
+
+            return createElement('div')('content')
+          }))
+
+          expect(log).toEqual([])
+
+          $visible(true)
+
+          expect(log).toEqual(['deferred 1'])
+          log.length = 0
+
+          $visible(false)
+
+          expect(log).toEqual(['cleanup'])
+          log.length = 0
+
+          $value(2)
+
+          expect(log).toEqual([])
+
+          $visible(true)
+
+          expect(log).toEqual(['deferred 2'])
+        })
+
+        it('should keep an inner hidden show down across outer toggles', () => {
+          const $outer = signal(true)
+          const $inner = signal(false)
+          const log: string[] = []
+          const { container } = render(() => show($outer, () => createElement('div')(
+            'outer',
+            show($inner, () => {
+              effect(() => {
+                log.push('inner effect')
+              })
+
+              return createElement('span')('inner')
+            })
+          )))
+
+          expect(container.innerHTML).toBe('<div><div>outer</div></div>')
+          expect(log).toEqual([])
+
+          $outer(false)
+          $outer(true)
+
+          expect(container.innerHTML).toBe('<div><div>outer</div></div>')
+          expect(log).toEqual([])
+
+          $inner(true)
+
+          expect(container.innerHTML).toBe('<div><div>outer<span>inner</span></div></div>')
+          expect(log).toEqual(['inner effect'])
+
+          $outer(false)
+          $outer(true)
+
+          expect(container.innerHTML).toBe('<div><div>outer<span>inner</span></div></div>')
+        })
+
+        it('should apply an inner toggle flipped before the first show of the outer', () => {
+          const $outer = signal(false)
+          const $inner = signal(true)
+          const log: string[] = []
+          const { container } = render(() => show($outer, () => createElement('div')(
+            'outer',
+            show($inner, () => {
+              effect(() => {
+                log.push('inner effect')
+              })
+
+              return createElement('span')('inner')
+            })
+          )))
+
+          $inner(false)
+
+          expect(log).toEqual([])
+
+          $outer(true)
+
+          expect(container.innerHTML).toBe('<div><div>outer</div></div>')
+          expect(log).toEqual([])
+
+          $inner(true)
+
+          expect(container.innerHTML).toBe('<div><div>outer<span>inner</span></div></div>')
+          expect(log).toEqual(['inner effect'])
+        })
+
+        it('should apply a value written back from inside a waking effect', () => {
+          const $visible = signal(false)
+          const { container } = render(() => show($visible, () => {
+            effect(() => {
+              $visible(false)
+            })
+
+            return createElement('div')('content')
+          }))
+
+          $visible(true)
+
+          expect(container.innerHTML).toBe('<div></div>')
+        })
+
+        it('should run cleanups while the DOM is still attached', () => {
+          const $visible = signal(true)
+          let connected: boolean | undefined
+          const { container } = render(() => show($visible, () => {
+            const el = createElement('div')('content')
+
+            effect(() => () => {
+              connected = el.isConnected
+            })
+
+            return el
+          }))
+
+          expect(container.innerHTML).toBe('<div><div>content</div></div>')
+
+          $visible(false)
+
+          expect(connected).toBe(true)
+        })
+
+        it('should apply an inner toggle flipped while the outer is hidden', () => {
+          const $outer = signal(true)
+          const $inner = signal(false)
+          const log: string[] = []
+          const { container } = render(() => show($outer, () => createElement('div')(
+            'outer',
+            show($inner, () => {
+              effect(() => {
+                log.push('inner effect')
+              })
+
+              return createElement('span')('inner')
+            })
+          )))
+
+          $outer(false)
+          $inner(true)
+
+          expect(log).toEqual([])
+
+          $outer(true)
+
+          expect(container.innerHTML).toBe('<div><div>outer<span>inner</span></div></div>')
+          expect(log).toEqual(['inner effect'])
+
+          $outer(false)
+          $inner(false)
+          $outer(true)
+
+          expect(container.innerHTML).toBe('<div><div>outer</div></div>')
+          expect(log).toEqual(['inner effect'])
+        })
+      })
+    })
+  })
+})

--- a/packages/nanoviews/src/internals/flow/show.ts
+++ b/packages/nanoviews/src/internals/flow/show.ts
@@ -1,0 +1,68 @@
+import {
+  type Accessor,
+  effect,
+  untracked,
+  boundDeferScope,
+  startScope,
+  pauseScope,
+  resumeScope
+} from 'kida'
+import type { Child } from '../types/index.js'
+import { createTextNode } from '../elements/text.js'
+import {
+  insertChildBeforeAnchor,
+  extractBetween
+} from '../elements/child.js'
+
+export function show(
+  $value: Accessor<unknown>,
+  render: () => Child
+) {
+  const start = createTextNode()
+  const end = createTextNode()
+  const fragment = document.createDocumentFragment()
+  // The parked fragment doubles as the hidden flag, and `noDefer` effects
+  // keep the parked DOM up to date
+  let parked: DocumentFragment | undefined
+
+  fragment.append(start, end)
+
+  // The first pass hands the whole tree over in its initial state: the
+  // content is built right here, under the caller's injection context, and
+  // held back - the toggle below owns its starts, so a value flipped
+  // before the first one never wakes the tree
+  const scope = boundDeferScope()(() => {
+    insertChildBeforeAnchor(render(), end)
+  })
+
+  pauseScope(scope)
+
+  if (!untracked($value)) {
+    parked = extractBetween(start, end)
+  }
+
+  effect(() => {
+    if ($value()) {
+      if (parked !== undefined) {
+        end.before(parked)
+        parked = undefined
+      }
+
+      // The first show claims the deferral token, every next one only
+      // lifts the pause; whichever applies, the other is a no-op
+      resumeScope(startScope(scope))
+    } else if (parked === undefined) {
+      // Cleanups run first, while their DOM is still attached
+      pauseScope(scope)
+      parked = extractBetween(start, end)
+    }
+  })
+
+  // The echo: a value written back from inside the running toggle cannot
+  // re-queue it. This second subscriber is idle at that moment, so its
+  // read settles the value and re-queues the parked toggle for the
+  // corrective pass
+  effect(() => void $value(), true)
+
+  return fragment
+}

--- a/packages/store/.size-limit.json
+++ b/packages/store/.size-limit.json
@@ -4,13 +4,13 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "6.35 kB"
+    "limit": "6.5 kB"
   },
   {
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "5.85 kB"
+    "limit": "5.95 kB"
   },
   {
     "name": "Signal (Gzip)",


### PR DESCRIPTION
The Activity/KeepAlive story: a subtree that lives regardless of visibility, shown and hidden without being rebuilt.

The core grows a restorable pause for deferred scopes. `pauseScope` puts a started scope down without destroying anything: effect cleanups run while their DOM is still attached, subscriptions drop, the nodes keep their places. `resumeScope` warms the bodies back up, and the re-run is also what syncs everything the subtree slept through. The state machine stays two mode bits: a `DeferredMode` mark, minted in the same assignment as the laziness token, names exactly what a pause may take - signals and computeds captured by a scope-body read, `noDefer` effects and anything stopped meanwhile stay untouched. Own effects wake before nested scopes - the mirror image of the start order - so a controller effect re-checks its world stale from the sleep and bars its scope before the walk below could wake it: a scope paused on its own stays down across an outer pause and resume, with not a single transient run. A scope paused before its first start does not start with its parent at all.

`show_($value, render)` builds its tree once, right in the first pass and under the caller's injection context, held back so the toggle owns its starts - a value flipped before the first show never wakes the tree. Hiding parks the same nodes into a fragment where `noDefer` bindings keep them fresh; showing puts them back and lifts the pause. The first show claims the deferral token, every next one lifts the pause, and whichever applies, the other is a no-op. An echo reader mirrors `swap`: a value written back from inside the waking tree re-queues the toggle for the corrective pass. Statics stay free: truthy hands the render result over, falsy is `null` without calling it.

The shape survived a three-way max-effort review (two Claude agents and Codex at ultra reasoning), which caught a pause-walk crash on scope-body signal reads, a stopped-effect resurrection in the resume walk, the write-back race and a first-reveal transient - all fixed and pinned by tests. One known limitation is documented by the review rather than the code: a branch swapped inside a hidden `show_` arrives with its deferred effects already live, because the `noDefer` swapper starts the fresh scope itself; the fix (an ancestor gate plus held-scope lifts on resume) taxes every scope start, so it is left as a deliberate open question.

Sizes: the pause layer is pay-per-use - agera Signal/Minimal/Popular subsets and the nanoviews Average usage set measure at their pre-feature bytes. All-publics pins move with the feature: agera 3.15 → 3.3 kB gzip and 2.9 → 3.05 brotli, nanoviews 7.7 → 7.9 and 6.8 → 7.05, and in tow kida 4.95 → 5.1 / 4.6 → 4.7 and store 6.35 → 6.5 / 5.85 → 5.95.

Lint, `tsc --noEmit`, 166 agera, 154 nanoviews, 69 kida, 55 store and 163 query tests, and size-limit across the chain are green.