### PR TITLE
fix(kida): keep `onMount` subscribed when a signal remounts within the unmount delay

### DIFF
--- a/packages/kida/src/internals/lifecycle.spec.ts
+++ b/packages/kida/src/internals/lifecycle.spec.ts
@@ -206,6 +206,36 @@ describe('kida', () => {
           expect(unmount).toHaveBeenCalledTimes(2)
         })
 
+        it('should cancel scheduled unmount on remount', () => {
+          const $signal = mountable(signal(1))
+          const unmount = vi.fn()
+          const mount = vi.fn(() => unmount)
+
+          onMount($signal, mount)
+
+          const off1 = effect(() => {
+            $signal()
+          })
+
+          off1()
+          vi.advanceTimersByTime(100)
+
+          const off2 = effect(() => {
+            $signal()
+          })
+
+          vi.advanceTimersByTime(STORE_UNMOUNT_DELAY + 1)
+
+          expect(mount).toHaveBeenCalledTimes(1)
+          expect(unmount).not.toHaveBeenCalled()
+
+          off2()
+          vi.advanceTimersByTime(STORE_UNMOUNT_DELAY + 1)
+
+          expect(mount).toHaveBeenCalledTimes(1)
+          expect(unmount).toHaveBeenCalledTimes(1)
+        })
+
         it('should call listener while set value in onMount', () => {
           const $signal = mountable(signal(1))
           const listener = vi.fn()

--- a/packages/kida/src/internals/lifecycle.ts
+++ b/packages/kida/src/internals/lifecycle.ts
@@ -63,22 +63,23 @@ export function onMount(
   $signal: Mountable<AnySignal>,
   listener: () => MaybeDestroy
 ) {
-  let active = false
   let destroy: MaybeDestroy
+  let timer: ReturnType<typeof setTimeout> | undefined
 
   return onMounted($signal, (mounted) => {
     if (mounted) {
-      if (!active) {
+      // A pending teardown is the listener still being alive: cancel it
+      // instead of starting a second one. Levels alternate per listener, so
+      // no timer means it was torn down and has to be started anew
+      if (timer) {
+        clearTimeout(timer)
+      } else {
         destroy = listener()
-        active = true
       }
     } else {
-      setTimeout(() => {
-        if (active) {
-          destroy?.()
-          destroy = undefined
-          active = false
-        }
+      timer = setTimeout(() => {
+        destroy?.()
+        destroy = timer = undefined
       }, STORE_UNMOUNT_DELAY)
     }
   })


### PR DESCRIPTION
## The bug

`onMount` arms a `setTimeout` on unmount and never cancels it. A signal that remounts inside `STORE_UNMOUNT_DELAY` therefore loses its subscription one second later, while it is mounted and being read, and it never gets it back: `evaluate` delivers the mount level on a change, so no further mount fires until a full unmount and mount cycle happens.

Everything built on `onMount` inherits it. `paced` keeps its source subscription there, so a paced signal goes quiet after a quick route remount. React StrictMode reaches the same state on every double-invoked `subscribe`.

## Why the existing tests missed it

`should debounce unmount callback` follows every remount with an immediate unmount, so when the first timer finally fires the signal really is unmounted and the teardown is legitimate. It pins the debounce, not the cancellation. `should dispatch onMount event` runs `vi.runAllTimers()` between transitions, so a timer never survives a remount.

The new case is the one that was missing: mount, unmount, remount after 100 ms, advance past `STORE_UNMOUNT_DELAY`, assert the unmount listener was never called. It fails on `main` with `expected "vi.fn()" to not be called at all, but actually been called 1 times`.

## The fix

The pending timer now holds the state `active` used to. A mount with a teardown scheduled cancels it instead of starting a second listener; a mount without one starts the listener; the teardown clears the timer. Per listener the levels alternate strictly, since `evaluate` only delivers an unchanged level to listeners past the `lcf` cursor and the unmount branch requires `changed`, so those two cases cover every delivery and the flag is redundant.

## Size

Dropping the flag pays for the cancellation: measured on kida's bundle, raw 21562 → 21522 B, gzip 5067 → 5061 B against `main`. No `.size-limit.json` changes needed.

## Verification

Unit tests green in kida (70), store (55), router (129) and query (163). `oxlint` and `tsc --noEmit` clean for kida. `test:size` run sequentially across all 13 packages with no exceedances.
