### PR TITLE
feat(kida): add `latest` for the value of the source that changed last

### DIFF
--- a/packages/kida/.size-limit.json
+++ b/packages/kida/.size-limit.json
@@ -4,13 +4,13 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "5 kB"
+    "limit": "5.05 kB"
   },
   {
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "4.65 kB"
+    "limit": "4.7 kB"
   },
   {
     "name": "Signal (Gzip)",

--- a/packages/kida/src/utils.spec.ts
+++ b/packages/kida/src/utils.spec.ts
@@ -1,0 +1,114 @@
+import {
+  vi,
+  describe,
+  it,
+  expect
+} from 'vitest'
+import {
+  signal,
+  effect,
+  batch
+} from 'agera'
+import { latest } from './utils.js'
+
+describe('kida', () => {
+  describe('utils', () => {
+    describe('latest', () => {
+      it('should return the last source value on the first read', () => {
+        const $a = signal('a')
+        const $b = signal('b')
+        const $latest = latest($a, $b)
+
+        expect($latest()).toBe('b')
+      })
+
+      it('should return the last source value on the first read when it is undefined', () => {
+        const $a = signal<string | undefined>('a')
+        const $b = signal<string | undefined>(undefined)
+        const $latest = latest($a, $b)
+
+        expect($latest()).toBeUndefined()
+      })
+
+      it('should return the value of the source that changed last', () => {
+        const $a = signal('a')
+        const $b = signal('b')
+        const $latest = latest($a, $b)
+        const listener = vi.fn()
+        const off = effect(() => {
+          listener($latest())
+        })
+
+        $a('a1')
+        $b('b1')
+        $a('a2')
+
+        expect(listener.mock.calls).toEqual([['b'], ['a1'], ['b1'], ['a2']])
+
+        off()
+      })
+
+      it('should return the last changed source when several sources changed in a batch', () => {
+        const $a = signal('a')
+        const $b = signal('b')
+        const $latest = latest($a, $b)
+        const off = effect(() => {
+          $latest()
+        })
+
+        batch(() => {
+          $b('b1')
+          $a('a1')
+        })
+
+        expect($latest()).toBe('b1')
+
+        off()
+      })
+
+      it('should return the last changed source when several sources changed between reads', () => {
+        const $a = signal('a')
+        const $b = signal('b')
+        const $latest = latest($a, $b)
+
+        expect($latest()).toBe('b')
+
+        $b('b1')
+        $a('a1')
+
+        expect($latest()).toBe('b1')
+      })
+
+      it('should keep the value when a source is written with an equal value', () => {
+        const $a = signal('a')
+        const $b = signal('b')
+        const $latest = latest($a, $b)
+
+        expect($latest()).toBe('b')
+
+        $a('a')
+
+        expect($latest()).toBe('b')
+      })
+
+      it('should keep the value when nothing changed since the last read', () => {
+        const $a = signal('a')
+        const $b = signal('b')
+        const $latest = latest($a, $b)
+        const off = effect(() => {
+          $latest()
+        })
+
+        $a('a1')
+
+        expect($latest()).toBe('a1')
+
+        // Losing the last subscriber purges the deps and forces the next read
+        // to recompute with no source changed
+        off()
+
+        expect($latest()).toBe('a1')
+      })
+    })
+  })
+})

--- a/packages/kida/src/utils.ts
+++ b/packages/kida/src/utils.ts
@@ -54,6 +54,39 @@ export function concat(...parts: Signalish<unknown>[]) {
 }
 
 /**
+ * Create a signal with the value of the source that changed last.
+ * A change is a change of value: writing a value equal to the current one
+ * changes nothing. The last source wins on the first read and whenever
+ * several sources changed since the previous read, which is what reading
+ * without a subscription or writing inside a `batch` amounts to.
+ * @param sources - Sources to merge.
+ * @returns A signal with the value of the most recently changed source.
+ */
+/* @__NO_SIDE_EFFECTS__ */
+export function latest<T>(...sources: Accessor<T>[]) {
+  const prev: T[] = []
+  let value: T
+
+  return computed(() => {
+    // The first run has nothing to compare against, so every source counts as
+    // changed and the last one wins
+    const init = !prev.length
+
+    // Every source is read on every run: skipping one drops its subscription
+    for (let i = 0, len = sources.length; i < len; i++) {
+      const next = sources[i]()
+
+      if (init || next !== prev[i]) {
+        prev[i] = next
+        value = next
+      }
+    }
+
+    return value
+  })
+}
+
+/**
  * Compose multiple destroy functions into a single destroy function.
  * @param destroys - Destroy functions to compose.
  * @returns A single destroy function that calls all provided destroy functions.

--- a/packages/store/.size-limit.json
+++ b/packages/store/.size-limit.json
@@ -4,13 +4,13 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "6.4 kB"
+    "limit": "6.45 kB"
   },
   {
     "name": "All publics (Brotli)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "5.9 kB"
+    "limit": "5.95 kB"
   },
   {
     "name": "Signal (Gzip)",


### PR DESCRIPTION
## What

`latest(...sources)` returns a signal carrying the value of whichever source changed most recently.

```ts
const $searchQuery = signal('')
const $searchParam = searchParam($searchParams, 'q', v => v ?? '')
const $search = latest($searchQuery, $searchParam)
```

Typing wins over the URL, navigation wins over what was typed. It is the missing half of `previous` from `@nano_kit/store`: that one looks back through a single source, this one picks the freshest across several. It lives in `kida`, so `@nano_kit/store` re-exports it too.

## Contract

- The last source wins on the first read, whatever its value, `undefined` included.
- The last source also wins whenever several sources changed since the previous read. That covers writes inside one `batch`, sources sharing an upstream, and reads made without a subscription.
- A change is a change of value: a write of an equal value is invisible, and so is `a → b → a` inside one batch.
- The winner is kept, not recomputed. Losing the last subscriber purges the deps and leaves the node dirty, so the next read recomputes with nothing changed; a util that re-picked a winner there would flip its answer on every remount.
- Every source is read on every run. An early exit on the first change would drop the subscriptions of the sources after it.

## Tests

Seven cases in `packages/kida/src/utils.spec.ts` pin every rule above. They were checked against wrong implementations rather than only against a green run:

| mutation | caught by |
|---|---|
| drop the first-run branch | `should return the last source value on the first read when it is undefined` |
| `break` after the first change | five of seven, subscriptions are lost |
| re-pick the winner instead of keeping it | `should keep the value when nothing changed since the last read` |

## Size

`latest` costs 60 B gzip and 52 B brotli in kida's `All publics`: 4989 → 5049 and 4604 → 4656. Both `All publics` entries are re-pinned in `kida` and in `store`, which mirrors them through the re-export. `Signal` and `Popular set` are untouched, the util is not in those sets.

## Verification

kida unit tests green (87), `oxlint` and `tsc --noEmit` clean, `test:size` run sequentially across all 13 packages with no exceedances.
