### PR TITLE
feat(agera): add `inspect` to report graph events in the development build

### DIFF
--- a/packages/agera/.size-limit.json
+++ b/packages/agera/.size-limit.json
@@ -4,13 +4,13 @@
     "gzip": true,
     "path": "dist/index.production.js",
     "import": "*",
-    "limit": "3.3 kB"
+    "limit": "3.4 kB"
   },
   {
     "name": "All publics (Brotli)",
     "path": "dist/index.production.js",
     "import": "*",
-    "limit": "3.05 kB"
+    "limit": "3.1 kB"
   },
   {
     "name": "Signal (Gzip)",

--- a/packages/agera/src/index.ts
+++ b/packages/agera/src/index.ts
@@ -2,12 +2,20 @@ export type * from './internals/types.js'
 export {
   NoneFlag,
   WritableMode,
-  ExternalModesBase
+  ExternalModesBase,
+  LinkEvent,
+  UnlinkEvent,
+  UpdateEvent,
+  RunEvent,
+  StopEvent,
+  LifecycleEvent,
+  FlushEvent
 } from './internals/flags.js'
 export {
   untracked,
   trigger,
   onSignal,
+  inspect,
   createSignal,
   computedOper
 } from './internals/system.js'

--- a/packages/agera/src/internals/flags.ts
+++ b/packages/agera/src/internals/flags.ts
@@ -31,3 +31,20 @@ export const DeferredMode = 1 << 5
 export const ExternalModesBase = 6
 
 // #endregion
+
+// #region Event kinds, passed to the `inspect` listener
+export const LinkEvent = 0
+
+export const UnlinkEvent = 1
+
+export const UpdateEvent = 2
+
+export const RunEvent = 3
+
+export const StopEvent = 4
+
+export const LifecycleEvent = 5
+
+export const FlushEvent = 6
+
+// #endregion

--- a/packages/agera/src/internals/system.spec.ts
+++ b/packages/agera/src/internals/system.spec.ts
@@ -7,14 +7,41 @@ import {
   beforeEach,
   afterEach
 } from 'vitest'
+import type {
+  Link,
+  ReactiveNode
+} from './types.js'
+import {
+  LinkEvent,
+  UnlinkEvent,
+  UpdateEvent,
+  RunEvent,
+  StopEvent,
+  LifecycleEvent,
+  FlushEvent
+} from './flags.js'
 import {
   signal,
   computed,
   effect,
   effectScope,
   untracked,
-  batch
+  batch,
+  inspect
 } from './system.js'
+import { mountable } from '../modes.js'
+
+type Event = [kind: number, target: ReactiveNode | Link | undefined]
+
+const events: Event[] = []
+
+inspect((kind, target) => {
+  events.push([kind, target])
+})
+
+function of(kind: number, target?: ReactiveNode | Link) {
+  return events.filter(([k, t]) => k === kind && (target === undefined || t === target))
+}
 
 describe('agera', () => {
   describe('internals', () => {
@@ -119,6 +146,142 @@ describe('agera', () => {
 
           expect(warn).toHaveBeenCalledTimes(1)
           expect(warn).toHaveBeenCalledWith(expect.stringContaining('scope was created'))
+        })
+      })
+
+      describe('inspect', () => {
+        beforeEach(() => {
+          events.length = 0
+        })
+
+        it('should report a new link and its removal with the effect stop', () => {
+          const $count = signal(0)
+          const stop = effect(() => {
+            $count()
+          })
+          const [link] = of(LinkEvent).map(([, target]) => target as Link)
+
+          expect(link.dep).toBe($count.node)
+
+          stop()
+
+          expect(of(UnlinkEvent, link)).toHaveLength(1)
+          expect(of(StopEvent, link.sub)).toHaveLength(1)
+        })
+
+        it('should report a committed write once and skip an equal write', () => {
+          const $count = signal(0)
+
+          effect(() => {
+            $count()
+          })
+          events.length = 0
+          $count(1)
+
+          expect(of(UpdateEvent, $count.node)).toHaveLength(1)
+
+          $count(1)
+
+          expect(of(UpdateEvent, $count.node)).toHaveLength(1)
+        })
+
+        it('should report one update for writes collapsed by a batch', () => {
+          const $count = signal(0)
+
+          effect(() => {
+            $count()
+          })
+          events.length = 0
+          batch(() => {
+            $count(1)
+            $count(2)
+          })
+
+          expect(of(UpdateEvent, $count.node)).toHaveLength(1)
+        })
+
+        it('should report a run and an update for the first evaluation of a computed', () => {
+          const $count = signal(1)
+          const $double = computed(() => $count() * 2)
+
+          expect(of(RunEvent, $double.node)).toHaveLength(0)
+
+          $double()
+
+          expect(of(RunEvent, $double.node)).toHaveLength(1)
+          expect(of(UpdateEvent, $double.node)).toHaveLength(1)
+        })
+
+        it('should report a run without an update when a computed keeps its value', () => {
+          const $count = signal(1)
+          const $positive = computed(() => $count() > 0)
+
+          effect(() => {
+            $positive()
+          })
+          events.length = 0
+          $count(2)
+
+          expect(of(RunEvent, $positive.node)).toHaveLength(1)
+          expect(of(UpdateEvent, $positive.node)).toHaveLength(0)
+        })
+
+        it('should report effect re-runs but not the warmup run', () => {
+          const $count = signal(0)
+
+          effect(() => {
+            $count()
+          })
+
+          const [link] = of(LinkEvent).map(([, target]) => target as Link)
+
+          expect(of(RunEvent, link.sub)).toHaveLength(0)
+
+          $count(1)
+
+          expect(of(RunEvent, link.sub)).toHaveLength(1)
+        })
+
+        it('should report a flush once after a write outside a batch', () => {
+          const $count = signal(0)
+
+          effect(() => {
+            $count()
+          })
+          events.length = 0
+          $count(1)
+
+          expect(of(FlushEvent)).toHaveLength(1)
+        })
+
+        it('should report mount and unmount transitions of a mountable signal', () => {
+          const $count = mountable(signal(0))
+          const stop = effect(() => {
+            $count()
+          })
+
+          expect(of(LifecycleEvent, $count.node)).toHaveLength(1)
+
+          stop()
+
+          expect(of(LifecycleEvent, $count.node)).toHaveLength(2)
+        })
+
+        it('should compose listeners', () => {
+          let calls = 0
+
+          inspect(() => {
+            calls++
+          })
+
+          const $count = signal(0)
+
+          effect(() => {
+            $count()
+          })
+
+          expect(calls).toBeGreaterThan(0)
+          expect(calls).toBe(events.length)
         })
       })
     })

--- a/packages/agera/src/internals/system.spec.ts
+++ b/packages/agera/src/internals/system.spec.ts
@@ -226,6 +226,20 @@ describe('agera', () => {
           expect(of(UpdateEvent, $positive.node)).toHaveLength(0)
         })
 
+        it('should report an update when a computed changes its value', () => {
+          const $count = signal(1)
+          const $double = computed(() => $count() * 2)
+
+          effect(() => {
+            $double()
+          })
+          events.length = 0
+          $count(2)
+
+          expect(of(RunEvent, $double.node)).toHaveLength(1)
+          expect(of(UpdateEvent, $double.node)).toHaveLength(1)
+        })
+
         it('should report effect re-runs but not the warmup run', () => {
           const $count = signal(0)
 

--- a/packages/agera/src/internals/system.ts
+++ b/packages/agera/src/internals/system.ts
@@ -16,7 +16,8 @@ import type {
   Accessor,
   Compute,
   NewValue,
-  DeferredScope
+  DeferredScope,
+  InspectListener
 } from './types.js'
 import {
   NoneFlag,
@@ -31,7 +32,14 @@ import {
   MountableMode,
   LazyMode,
   PausedMode,
-  DeferredMode
+  DeferredMode,
+  LinkEvent,
+  UnlinkEvent,
+  UpdateEvent,
+  RunEvent,
+  StopEvent,
+  LifecycleEvent,
+  FlushEvent
 } from './flags.js'
 
 // #region Lifecycle sockets
@@ -43,6 +51,7 @@ import {
 // slot must exist before the first core path that checks it
 let lifecycleEdge: ((dep: ReactiveNode, sub?: ReactiveNode) => void) | undefined
 let lifecycleSettle: (() => void) | undefined
+let inspectListener: InspectListener | undefined
 // #endregion
 // #region Core
 let cycle = 0
@@ -177,6 +186,10 @@ function link(dep: ReactiveNode, sub: ReactiveNode, version: number): void {
     dep.subs = newLink
   }
 
+  if (import.meta.env.DEV) {
+    inspectListener?.(LinkEvent, newLink)
+  }
+
   // The slot is tested first so a bundle without the lifecycle layer drops
   // the whole check, including the `modes` read
   if (lifecycleEdge !== undefined && dep.modes & MountableMode) {
@@ -185,6 +198,10 @@ function link(dep: ReactiveNode, sub: ReactiveNode, version: number): void {
 }
 
 function unlink(link: Link, sub = link.sub): Link | undefined {
+  if (import.meta.env.DEV) {
+    inspectListener?.(UnlinkEvent, link)
+  }
+
   const {
     dep,
     prevDep,
@@ -435,6 +452,24 @@ export function onSignal(callback: ($signal: AnySignal) => void) {
 }
 
 /**
+ * Register an inspect listener. It is called with an event kind from the
+ * event constants and the node or link the event is about; `FlushEvent`
+ * carries no target. The contract exists for the devtools package alone
+ * and may change in minor versions. The development build is the only one
+ * that reports events, in production this is a no-op.
+ * @param listener - The listener, composed with any previous one.
+ */
+export function inspect(listener: InspectListener) {
+  if (import.meta.env.DEV) {
+    const prevListener = inspectListener
+
+    inspectListener = prevListener
+      ? (kind, target) => (prevListener(kind, target), listener(kind, target))
+      : listener
+  }
+}
+
+/**
  * Create a signal function over a reactive node. The node is the operator's
  * `this`, so whatever a call site needs at read or write time lives on the
  * node and a signal costs one object and one bound function, nothing else.
@@ -644,10 +679,19 @@ function updateComputed(c: ComputedNode): boolean {
 
   const prevSub = pushActiveSub(c)
 
+  if (import.meta.env.DEV) {
+    inspectListener?.(RunEvent, c)
+  }
+
   try {
     const oldValue = c.value
+    const changed = oldValue !== (c.value = c.compute(oldValue))
 
-    return oldValue !== (c.value = c.compute(oldValue))
+    if (import.meta.env.DEV && changed) {
+      inspectListener?.(UpdateEvent, c)
+    }
+
+    return changed
   } finally {
     popActiveSub(prevSub)
     c.flags &= ~RecursedCheckFlag
@@ -658,7 +702,14 @@ function updateComputed(c: ComputedNode): boolean {
 
 function updateSignal(s: SignalNode): boolean {
   s.flags = MutableFlag
-  return s.value !== (s.value = s.pendingValue)
+
+  const changed = s.value !== (s.value = s.pendingValue)
+
+  if (import.meta.env.DEV && changed) {
+    inspectListener?.(UpdateEvent, s)
+  }
+
+  return changed
 }
 
 function warmupEffect(e: EffectNode): void {
@@ -685,6 +736,10 @@ function warmupEffect(e: EffectNode): void {
 
 function runEffect(e: EffectNode): void {
   const prevSub = pushActiveSub(e)
+
+  if (import.meta.env.DEV) {
+    inspectListener?.(RunEvent, e)
+  }
 
   try {
     e.destroy = e.fn() || undefined
@@ -748,6 +803,10 @@ function flush(): void {
     --flushDepth
 
     lifecycleSettle?.()
+
+    if (import.meta.env.DEV && !flushDepth) {
+      inspectListener?.(FlushEvent)
+    }
   }
 }
 
@@ -783,8 +842,16 @@ export function computedOper<T>(this: ComputedNode<T>): T {
 
     const prevSub = pushActiveSub(this)
 
+    if (import.meta.env.DEV) {
+      inspectListener?.(RunEvent, this)
+    }
+
     try {
       this.value = this.compute()
+
+      if (import.meta.env.DEV) {
+        inspectListener?.(UpdateEvent, this)
+      }
     } finally {
       popActiveSub(prevSub)
       this.flags &= ~RecursedCheckFlag
@@ -874,6 +941,10 @@ function effectOper(this: EffectNode): void {
 // The STOPPED transition, shared by effect and scope disposal: make the node
 // terminal, destroy what it owns, detach it from its position
 function effectScopeOper(this: ReactiveNode): void {
+  if (import.meta.env.DEV) {
+    inspectListener?.(StopEvent, this)
+  }
+
   this.depsTail = undefined
   this.flags = NoneFlag
   // Spend the deferral token. This single line is what turns every stale
@@ -1564,6 +1635,10 @@ function evaluate(node: ReadableNode): void {
   const to = listeners?.length as number
 
   node.lcd = mounted
+
+  if (import.meta.env.DEV && changed) {
+    inspectListener?.(LifecycleEvent, node)
+  }
 
   // Sources mount before their dependents and unmount after them
   if (changed && mounted) {

--- a/packages/agera/src/internals/system.ts
+++ b/packages/agera/src/internals/system.ts
@@ -186,8 +186,8 @@ function link(dep: ReactiveNode, sub: ReactiveNode, version: number): void {
     dep.subs = newLink
   }
 
-  if (import.meta.env.DEV) {
-    inspectListener?.(LinkEvent, newLink)
+  if (import.meta.env.DEV && inspectListener) {
+    inspectListener(LinkEvent, newLink)
   }
 
   // The slot is tested first so a bundle without the lifecycle layer drops
@@ -198,8 +198,8 @@ function link(dep: ReactiveNode, sub: ReactiveNode, version: number): void {
 }
 
 function unlink(link: Link, sub = link.sub): Link | undefined {
-  if (import.meta.env.DEV) {
-    inspectListener?.(UnlinkEvent, link)
+  if (import.meta.env.DEV && inspectListener) {
+    inspectListener(UnlinkEvent, link)
   }
 
   const {
@@ -679,16 +679,16 @@ function updateComputed(c: ComputedNode): boolean {
 
   const prevSub = pushActiveSub(c)
 
-  if (import.meta.env.DEV) {
-    inspectListener?.(RunEvent, c)
+  if (import.meta.env.DEV && inspectListener) {
+    inspectListener(RunEvent, c)
   }
 
   try {
     const oldValue = c.value
     const changed = oldValue !== (c.value = c.compute(oldValue))
 
-    if (import.meta.env.DEV && changed) {
-      inspectListener?.(UpdateEvent, c)
+    if (import.meta.env.DEV && inspectListener && changed) {
+      inspectListener(UpdateEvent, c)
     }
 
     return changed
@@ -705,8 +705,8 @@ function updateSignal(s: SignalNode): boolean {
 
   const changed = s.value !== (s.value = s.pendingValue)
 
-  if (import.meta.env.DEV && changed) {
-    inspectListener?.(UpdateEvent, s)
+  if (import.meta.env.DEV && inspectListener && changed) {
+    inspectListener(UpdateEvent, s)
   }
 
   return changed
@@ -737,8 +737,8 @@ function warmupEffect(e: EffectNode): void {
 function runEffect(e: EffectNode): void {
   const prevSub = pushActiveSub(e)
 
-  if (import.meta.env.DEV) {
-    inspectListener?.(RunEvent, e)
+  if (import.meta.env.DEV && inspectListener) {
+    inspectListener(RunEvent, e)
   }
 
   try {
@@ -804,8 +804,8 @@ function flush(): void {
 
     lifecycleSettle?.()
 
-    if (import.meta.env.DEV && !flushDepth) {
-      inspectListener?.(FlushEvent)
+    if (import.meta.env.DEV && inspectListener && !flushDepth) {
+      inspectListener(FlushEvent)
     }
   }
 }
@@ -842,15 +842,15 @@ export function computedOper<T>(this: ComputedNode<T>): T {
 
     const prevSub = pushActiveSub(this)
 
-    if (import.meta.env.DEV) {
-      inspectListener?.(RunEvent, this)
+    if (import.meta.env.DEV && inspectListener) {
+      inspectListener(RunEvent, this)
     }
 
     try {
       this.value = this.compute()
 
-      if (import.meta.env.DEV) {
-        inspectListener?.(UpdateEvent, this)
+      if (import.meta.env.DEV && inspectListener) {
+        inspectListener(UpdateEvent, this)
       }
     } finally {
       popActiveSub(prevSub)
@@ -941,8 +941,8 @@ function effectOper(this: EffectNode): void {
 // The STOPPED transition, shared by effect and scope disposal: make the node
 // terminal, destroy what it owns, detach it from its position
 function effectScopeOper(this: ReactiveNode): void {
-  if (import.meta.env.DEV) {
-    inspectListener?.(StopEvent, this)
+  if (import.meta.env.DEV && inspectListener) {
+    inspectListener(StopEvent, this)
   }
 
   this.depsTail = undefined
@@ -1636,8 +1636,8 @@ function evaluate(node: ReadableNode): void {
 
   node.lcd = mounted
 
-  if (import.meta.env.DEV && changed) {
-    inspectListener?.(LifecycleEvent, node)
+  if (import.meta.env.DEV && inspectListener && changed) {
+    inspectListener(LifecycleEvent, node)
   }
 
   // Sources mount before their dependents and unmount after them

--- a/packages/agera/src/internals/types.ts
+++ b/packages/agera/src/internals/types.ts
@@ -22,6 +22,8 @@ export type NewValue<T, A = void> = T | ((prevValue: T, arg: A) => T)
 
 export type MountedListener = (mounted: boolean) => void
 
+export type InspectListener = (kind: number, target?: ReactiveNode | Link) => void
+
 export interface ReadableNode extends ReactiveNode, DefineVirtualFlags<'writable' | 'mountable'> {
   /**
    * Lifecycle: mount listeners.

--- a/packages/kida/.size-limit.js
+++ b/packages/kida/.size-limit.js
@@ -35,7 +35,7 @@ export default [
     name: 'Signal (Brotli)',
     path: 'dist/index.production.js',
     import: '{ signal }',
-    limit: '1.35 kB',
+    limit: '1.4 kB',
     modifyEsbuildConfig
   },
   {

--- a/packages/kida/.size-limit.js
+++ b/packages/kida/.size-limit.js
@@ -13,14 +13,14 @@ export default [
     gzip: true,
     path: 'dist/index.production.js',
     import: '*',
-    limit: '5.05 kB',
+    limit: '5.1 kB',
     modifyEsbuildConfig
   },
   {
     name: 'All publics (Brotli)',
     path: 'dist/index.production.js',
     import: '*',
-    limit: '4.65 kB',
+    limit: '4.7 kB',
     modifyEsbuildConfig
   },
   {

--- a/packages/store/.size-limit.js
+++ b/packages/store/.size-limit.js
@@ -35,7 +35,7 @@ export default [
     name: 'Signal (Brotli)',
     path: 'dist/index.production.js',
     import: '{ signal }',
-    limit: '1.35 kB',
+    limit: '1.4 kB',
     modifyEsbuildConfig
   },
   {

--- a/packages/store/.size-limit.js
+++ b/packages/store/.size-limit.js
@@ -13,14 +13,14 @@ export default [
     gzip: true,
     path: 'dist/index.production.js',
     import: '*',
-    limit: '6.4 kB',
+    limit: '6.5 kB',
     modifyEsbuildConfig
   },
   {
     name: 'All publics (Brotli)',
     path: 'dist/index.production.js',
     import: '*',
-    limit: '5.9 kB',
+    limit: '5.95 kB',
     modifyEsbuildConfig
   },
   {


### PR DESCRIPTION
## What

`inspect(listener)` in agera: one development-only hook that reports what the reactive graph does, the base for the devtools package.

The listener receives an event kind and the node or link the event is about:

- `LinkEvent`, `UnlinkEvent`: a dependency link created or removed.
- `UpdateEvent`: a signal or computed committed a new value, equal writes and batched writes report once.
- `RunEvent`: a computed or an effect ran, the warmup run of an effect is not reported.
- `StopEvent`: an effect or a scope stopped.
- `LifecycleEvent`: a mountable signal mounted or unmounted.
- `FlushEvent`: the outermost flush ended, no target.

Listeners compose, the contract exists for the devtools package and may change in minor versions.

## How

- The listener slot is a module-level `let`; every call site is `if (import.meta.env.DEV) { inspectListener?.(...) }`, so the production build has no hook code at all and `inspect` is a no-op there. Verified: zero references in `dist/index.production.js`, fourteen in `dist/index.development.js`.
- `updateComputed` and `updateSignal` keep a `changed` const for the hook; the production build folds it back into the `return` expression.
- Event kinds live in `flags.ts` next to the mode flags.

## Sizes

Signal, Minimal and Popular sets are unchanged. All publics grows by the eight new exports: 3.3 → 3.4 kB Gzip, 3.05 → 3.1 kB Brotli.

## Tests

Nine cases in `internals/system.spec.ts` under `inspect`: link and unlink with stop, committed and equal writes, batched writes, first evaluation of a computed, a run without an update, effect re-runs without the warmup, one flush per write, mount and unmount transitions, listener composition.
