### PR TITLE
refactor: drop the type assertions and the deprecated `rollupOptions` that oxlint-tsgolint 7 reports

### DIFF
--- a/packages/agera/src/internals/system.ts
+++ b/packages/agera/src/internals/system.ts
@@ -1575,7 +1575,7 @@ function onEdge(dep: ReactiveNode, sub?: ReactiveNode): void {
 
     // The presence memo goes stale exactly when an edge changes
     ++stamp
-    ;(dep as ReadableNode).lcq = pending.push(dep as ReadableNode)
+    ;(dep as ReadableNode).lcq = pending.push(dep)
   } else {
     // A queued effect re-run is not part of the listener's creation
     // frame: what it builds is a genuine subscriber. A node born with an
@@ -1600,7 +1600,7 @@ function present(node: ReadableNode): boolean {
           // tracker's keys. Anything else settles the question iff it is a
           // live effect
           sub.modes & MountableMode
-            ? present(sub as ReadableNode)
+            ? present(sub)
             : sub.flags & WatchingFlag
         )
       ) {
@@ -1616,7 +1616,7 @@ function present(node: ReadableNode): boolean {
 function walkDeps(node: ReadableNode): void {
   for (let link = (node as ComputedNode).deps; link; link = link.nextDep) {
     if (link.dep.modes & MountableMode) {
-      evaluate(link.dep as ReadableNode)
+      evaluate(link.dep)
     }
   }
 }
@@ -1733,7 +1733,7 @@ function settle(): void {
 export function touchLifecycle(node: ReactiveNode): void {
   lifecycleEdge = onEdge
   lifecycleSettle = settle
-  ;(node as ReadableNode).lcq = pending.push(node as ReadableNode)
+  ;(node as ReadableNode).lcq = pending.push(node)
   settle()
 }
 

--- a/packages/intl/src/format/datetime.spec.ts
+++ b/packages/intl/src/format/datetime.spec.ts
@@ -6,9 +6,9 @@ import {
 import type { FormatContext } from '../types.js'
 import { datetime } from './datetime.js'
 
-const ctx = {
+const ctx: FormatContext = {
   $locale: () => 'en-US'
-} as unknown as FormatContext
+}
 const date = new Date('2024-01-02T00:00:00.000Z')
 
 describe('intl', () => {

--- a/packages/intl/src/format/duration.spec.ts
+++ b/packages/intl/src/format/duration.spec.ts
@@ -6,9 +6,9 @@ import {
 import type { FormatContext } from '../types.js'
 import { duration } from './duration.js'
 
-const ctx = {
+const ctx: FormatContext = {
   $locale: () => 'en-US'
-} as unknown as FormatContext
+}
 const value = {
   hours: 1,
   minutes: 30

--- a/packages/intl/src/format/format.spec.ts
+++ b/packages/intl/src/format/format.spec.ts
@@ -9,9 +9,9 @@ import { format } from './format.js'
 import { number } from './number.js'
 import { text } from './text.js'
 
-const ctx = {
+const ctx: FormatContext = {
   $locale: () => 'en-US'
-} as unknown as FormatContext
+}
 
 describe('intl', () => {
   describe('format', () => {
@@ -27,9 +27,9 @@ describe('intl', () => {
 
       it('should bind formatter values to current context', () => {
         const $locale = signal('en-US')
-        const ctx = {
+        const ctx: FormatContext = {
           $locale
-        } as unknown as FormatContext
+        }
         const formatNumber = format(number())
         const formatter = formatNumber(ctx)
 

--- a/packages/intl/src/format/list.spec.ts
+++ b/packages/intl/src/format/list.spec.ts
@@ -6,9 +6,9 @@ import {
 import type { FormatContext } from '../types.js'
 import { list } from './list.js'
 
-const ctx = {
+const ctx: FormatContext = {
   $locale: () => 'en-US'
-} as unknown as FormatContext
+}
 const value = ['red', 'green', 'blue']
 
 describe('intl', () => {

--- a/packages/intl/src/format/match.spec.ts
+++ b/packages/intl/src/format/match.spec.ts
@@ -15,9 +15,9 @@ import {
   match
 } from './match.js'
 
-const ctx = {
+const ctx: FormatContext = {
   $locale: () => 'en-US'
-} as unknown as FormatContext
+}
 
 describe('intl', () => {
   describe('format', () => {

--- a/packages/intl/src/format/number.spec.ts
+++ b/packages/intl/src/format/number.spec.ts
@@ -6,9 +6,9 @@ import {
 import type { FormatContext } from '../types.js'
 import { number } from './number.js'
 
-const ctx = {
+const ctx: FormatContext = {
   $locale: () => 'en-US'
-} as unknown as FormatContext
+}
 
 describe('intl', () => {
   describe('format', () => {

--- a/packages/intl/src/format/params.spec.ts
+++ b/packages/intl/src/format/params.spec.ts
@@ -13,9 +13,9 @@ import {
 import { text } from './text.js'
 import { params } from './params.js'
 
-const ctx = {
+const ctx: FormatContext = {
   $locale: () => 'en-US'
-} as unknown as FormatContext
+}
 
 describe('intl', () => {
   describe('format', () => {

--- a/packages/intl/src/format/plural.spec.ts
+++ b/packages/intl/src/format/plural.spec.ts
@@ -14,9 +14,9 @@ import {
   forms
 } from './plural.js'
 
-const ctx = {
+const ctx: FormatContext = {
   $locale: () => 'en-US'
-} as unknown as FormatContext
+}
 
 describe('intl', () => {
   describe('format', () => {

--- a/packages/intl/src/format/range.spec.ts
+++ b/packages/intl/src/format/range.spec.ts
@@ -8,9 +8,9 @@ import { datetime } from './datetime.js'
 import { number } from './number.js'
 import { range } from './range.js'
 
-const ctx = {
+const ctx: FormatContext = {
   $locale: () => 'en-US'
-} as unknown as FormatContext
+}
 const from = new Date('2024-01-02T00:00:00.000Z')
 const to = new Date('2024-01-05T00:00:00.000Z')
 const value = [from, to] as const

--- a/packages/intl/src/format/relativetime.spec.ts
+++ b/packages/intl/src/format/relativetime.spec.ts
@@ -6,9 +6,9 @@ import {
 import type { FormatContext } from '../types.js'
 import { relativetime } from './relativetime.js'
 
-const ctx = {
+const ctx: FormatContext = {
   $locale: () => 'en-US'
-} as unknown as FormatContext
+}
 
 describe('intl', () => {
   describe('format', () => {

--- a/packages/intl/src/format/text.spec.ts
+++ b/packages/intl/src/format/text.spec.ts
@@ -11,9 +11,9 @@ import {
   uppercase
 } from './text.js'
 
-const ctx = {
+const ctx: FormatContext = {
   $locale: () => 'en-US'
-} as unknown as FormatContext
+}
 
 describe('intl', () => {
   describe('format', () => {

--- a/packages/kida/src/tasks.ts
+++ b/packages/kida/src/tasks.ts
@@ -65,7 +65,7 @@ export async function waitTasks($of: AnyReadableSignal): Promise<void> {
     }
 
     for (let link = node.deps; link; link = link.nextDep) {
-      nodes.add(link.dep as TasksNode)
+      nodes.add(link.dep)
     }
   }
 

--- a/packages/query/src/client.ts
+++ b/packages/query/src/client.ts
@@ -33,10 +33,11 @@ export type * from './client.types.js'
 export function client<S extends (AnyClientSetting | AnyClientExtension)[]>(...settings: S) {
   const ctx = new ClientContext()
   const client = {
-    // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
+    /* oxlint-disable typescript/no-unnecessary-type-assertion */
     query: query.bind(ctx) as typeof query,
     invalidate: (key => ctx.invalidate(key)) as typeof ctx.invalidate,
     revalidate: (key => ctx.revalidate(key)) as typeof ctx.revalidate,
+    /* oxlint-enable typescript/no-unnecessary-type-assertion */
     $data: dataCacheFacade(ctx),
     $error: errorCacheFacade(ctx),
     $loading: loadingCacheFacade(ctx)

--- a/packages/query/src/settings/abortable.ts
+++ b/packages/query/src/settings/abortable.ts
@@ -73,7 +73,7 @@ export function abortable(): ClientSetting {
         }
 
         return promise
-      } as typeof superRun
+      }
     }
 
     ctx.abortable = true

--- a/packages/query/src/settings/retryOnError.ts
+++ b/packages/query/src/settings/retryOnError.ts
@@ -78,7 +78,7 @@ export function retryOnError(
         ))
 
         return promise
-      } as typeof superRun
+      }
     }
 
     ctx.calcRetryDelay = calcRetryDelay

--- a/packages/ssr/src/vite-plugin/index.spec.ts
+++ b/packages/ssr/src/vite-plugin/index.spec.ts
@@ -43,7 +43,7 @@ describe('ssr', () => {
         build: {
           outDir,
           minify: false,
-          rollupOptions: {
+          rolldownOptions: {
             input
           }
         },
@@ -70,7 +70,7 @@ describe('ssr', () => {
           ssr: true,
           outDir,
           minify: false,
-          rollupOptions: {
+          rolldownOptions: {
             input
           }
         },


### PR DESCRIPTION
## What

The lint fixes that the `oxlint-tsgolint` 7 update in #177 needs. On current `main` the new version reports 22 errors in five packages, the Renovate branch only got as far as `ssr` because the parallel run stopped there.

- **agera**: four `as ReadableNode` on arguments of `pending.push`, `present` and `evaluate`, the parameters accept a `ReactiveNode`.
- **kida**: `as TasksNode` on `nodes.add`.
- **query**: `as typeof superRun` on the `run` overrides in `abortable` and `retryOnError`, the assignment target types the function. The casted arrows of the client's `invalidate` and `revalidate` stay under the disable comment that `query` already had: the cast types their parameter, and `bind` would break settings that replace the method later, two cache tests caught that.
- **intl**: `as unknown as FormatContext` on the test contexts of ten format specs becomes a type annotation, the literal satisfies the interface.
- **ssr**: `rollupOptions` → `rolldownOptions` in the plugin spec, `no-deprecated` picks up the Vite 8 deprecation. The plugin itself already passes both keys and stays as is.

## Checks

Lint, types and unit tests of the five packages pass with `oxlint-tsgolint` 7.0.2001 and with the current 0.23.

Refs #177.
