### PR TITLE
fix(ssr,react-ssr,preact-ssr,svelte-ssr): escape head values and the dehydrated snapshot in the rendered html

### DIFF
--- a/packages/preact-ssr/src/renderer/index.spec.tsx
+++ b/packages/preact-ssr/src/renderer/index.spec.tsx
@@ -3,6 +3,15 @@ import {
   it,
   expect
 } from 'vitest'
+import {
+  InjectionContext,
+  provide
+} from '@nano_kit/store'
+import {
+  Page$,
+  title
+} from '@nano_kit/router'
+import type { RenderData } from '@nano_kit/preact-ssr/renderer'
 import { renderer } from '../../test/app/renderer.jsx'
 
 renderer.manifest = {
@@ -51,6 +60,20 @@ describe('preact-ssr', () => {
       expect((await renderer.render('/')).html).toBe('<!doctype html><html><head><title>Home Page</title><meta charset="utf-8" /><script type="module" src="/assets/client-Dfg_FsOr.js" /></script></head><body><div id="app"><main><div>Home John Doe</div></main></div><script>window.__DEHYDRATED__=[["data",{"user":"John Doe"}]]</script></body></html>')
 
       expect((await renderer.render('/about')).html).toBe('<!doctype html><html><head><title>About Page</title><meta charset="utf-8" /><script type="module" src="/assets/client-Dfg_FsOr.js" /></script></head><body><div id="app"><main><div>About Miguel loves cheese</div></main></div><script>window.__DEHYDRATED__=[["data",{"info":"Miguel loves cheese"}]]</script></body></html>')
+    })
+
+    it('should escape the title', () => {
+      const data = {
+        context: new InjectionContext([provide(Page$, () => null)]),
+        head: [title('Tom & "Jerry" <3')],
+        dehydrated: [],
+        statusCode: 200,
+        redirect: null,
+        page: null,
+        setCookieHeaders: null
+      } as RenderData
+
+      expect(renderer.renderToString(data)).toContain('<title>Tom &amp; &quot;Jerry&quot; &lt;3</title>')
     })
   })
 })

--- a/packages/preact-ssr/src/renderer/index.tsx
+++ b/packages/preact-ssr/src/renderer/index.tsx
@@ -10,6 +10,7 @@ import {
   type RenderData,
   ROOT_ID,
   Renderer,
+  escapeHtml,
   headDescriptorToHtml
 } from '@nano_kit/ssr/renderer'
 
@@ -49,7 +50,7 @@ export class PreactRenderer extends Renderer {
     })
 
     if (title) {
-      head = `<title>${title}</title>${head}`
+      head = `<title>${escapeHtml(title)}</title>${head}`
     }
 
     return render(

--- a/packages/react-ssr/src/renderer/index.spec.tsx
+++ b/packages/react-ssr/src/renderer/index.spec.tsx
@@ -3,6 +3,15 @@ import {
   it,
   expect
 } from 'vitest'
+import {
+  InjectionContext,
+  provide
+} from '@nano_kit/store'
+import {
+  Page$,
+  title
+} from '@nano_kit/router'
+import type { RenderData } from '@nano_kit/react-ssr/renderer'
 import { renderer } from '../../test/app/renderer.jsx'
 
 renderer.manifest = {
@@ -51,6 +60,20 @@ describe('react-ssr', () => {
       expect((await renderer.render('/')).html).toBe('<!doctype html><html><head><title>Home Page</title><meta charset="utf-8" /><script type="module" src="/assets/client-Dfg_FsOr.js" /></script></head><body><div id="app"><main><div>Home <!-- -->John Doe</div></main></div><script>window.__DEHYDRATED__=[["data",{"user":"John Doe"}]]</script></body></html>')
 
       expect((await renderer.render('/about')).html).toBe('<!doctype html><html><head><title>About Page</title><meta charset="utf-8" /><script type="module" src="/assets/client-Dfg_FsOr.js" /></script></head><body><div id="app"><main><div>About <!-- -->Miguel loves cheese</div></main></div><script>window.__DEHYDRATED__=[["data",{"info":"Miguel loves cheese"}]]</script></body></html>')
+    })
+
+    it('should escape the title', () => {
+      const data = {
+        context: new InjectionContext([provide(Page$, () => null)]),
+        head: [title('Tom & "Jerry" <3')],
+        dehydrated: [],
+        statusCode: 200,
+        redirect: null,
+        page: null,
+        setCookieHeaders: null
+      } as RenderData
+
+      expect(renderer.renderToString(data)).toContain('<title>Tom &amp; &quot;Jerry&quot; &lt;3</title>')
     })
   })
 })

--- a/packages/react-ssr/src/renderer/index.tsx
+++ b/packages/react-ssr/src/renderer/index.tsx
@@ -10,6 +10,7 @@ import {
   type RenderData,
   ROOT_ID,
   Renderer,
+  escapeHtml,
   headDescriptorToHtml
 } from '@nano_kit/ssr/renderer'
 
@@ -49,7 +50,7 @@ export class ReactRenderer extends Renderer {
     })
 
     if (title) {
-      head = `<title>${title}</title>${head}`
+      head = `<title>${escapeHtml(title)}</title>${head}`
     }
 
     return renderToString(

--- a/packages/ssr/src/renderer/renderer.spec.ts
+++ b/packages/ssr/src/renderer/renderer.spec.ts
@@ -56,5 +56,11 @@ describe('ssr', () => {
         '<!doctype html><title>About Page</title><meta charset="utf-8" /><script type="module" src="/assets/client-Dfg_FsOr.js" /></script><script>window.__DEHYDRATED__=[["data",{"info":"Miguel loves cheese"}]]</script>Layout > About Miguel loves cheese'
       )
     })
+
+    it('should escape closing script tags in the dehydrated script', () => {
+      expect(renderer.dehydratedScript([
+        ['html', '</script><script>alert(1)</script>']
+      ])).toBe('window.__DEHYDRATED__=[["html","\\u003c/script>\\u003cscript>alert(1)\\u003c/script>"]]')
+    })
   })
 })

--- a/packages/ssr/src/renderer/renderer.ts
+++ b/packages/ssr/src/renderer/renderer.ts
@@ -59,11 +59,12 @@ export abstract class Renderer extends Manifest {
 
   /**
    * Generates a script to set the dehydrated state on the client.
+   * `<` is escaped so that a value containing `</script>` cannot close the tag.
    * @param dehydrated - The dehydrated state to be sent to the client.
    * @returns A string containing the script to set the dehydrated state on the client.
    */
   dehydratedScript(dehydrated: [string, unknown][]) {
-    return `window.__DEHYDRATED__=${JSON.stringify(dehydrated)}`
+    return `window.__DEHYDRATED__=${JSON.stringify(dehydrated).replace(/</g, '\\u003c')}`
   }
 
   /**

--- a/packages/ssr/src/renderer/utils.spec.ts
+++ b/packages/ssr/src/renderer/utils.spec.ts
@@ -1,0 +1,60 @@
+import {
+  describe,
+  it,
+  expect
+} from 'vitest'
+import {
+  link,
+  meta,
+  script
+} from '@nano_kit/router'
+import {
+  escapeHtml,
+  headDescriptorToHtml
+} from './utils.js'
+
+describe('ssr', () => {
+  describe('renderer', () => {
+    describe('utils', () => {
+      describe('escapeHtml', () => {
+        it('should escape html special characters', () => {
+          expect(escapeHtml('Tom & "Jerry" <3 >:)')).toBe('Tom &amp; &quot;Jerry&quot; &lt;3 &gt;:)')
+        })
+
+        it('should keep other characters as is', () => {
+          expect(escapeHtml("it's fine/ok?")).toBe("it's fine/ok?")
+        })
+      })
+
+      describe('headDescriptorToHtml', () => {
+        it('should escape attribute values', () => {
+          expect(headDescriptorToHtml(meta({
+            name: 'description',
+            content: 'Tom & "Jerry" <3'
+          }))).toBe('<meta name="description" content="Tom &amp; &quot;Jerry&quot; &lt;3" />')
+        })
+
+        it('should escape reactive attribute values', () => {
+          expect(headDescriptorToHtml(link({
+            rel: 'canonical',
+            href: () => '/search?q=<a>&b="c"'
+          }))).toBe('<link rel="canonical" href="/search?q=&lt;a&gt;&amp;b=&quot;c&quot;" />')
+        })
+
+        it('should skip empty attribute values', () => {
+          expect(headDescriptorToHtml(meta({
+            name: 'description',
+            content: null
+          }))).toBe('<meta name="description" />')
+        })
+
+        it('should insert script code as is', () => {
+          expect(headDescriptorToHtml(script({
+            type: 'application/ld+json',
+            code: '{"a":"<b>"}'
+          }))).toBe('<script type="application/ld+json" />{"a":"<b>"}</script>')
+        })
+      })
+    })
+  })
+})

--- a/packages/ssr/src/renderer/utils.ts
+++ b/packages/ssr/src/renderer/utils.ts
@@ -17,6 +17,58 @@ import {
   SUCCESS_STATUS
 } from './constants.js'
 
+const ESCAPE_HTML_RE = /[&<>"]/
+
+/**
+ * Escapes a string for HTML text content and double-quoted attribute values.
+ * A string without special characters is returned as is.
+ * @param value - The raw string.
+ * @returns The escaped string.
+ */
+export function escapeHtml(value: string) {
+  const match = ESCAPE_HTML_RE.exec(value)
+
+  if (!match) {
+    return value
+  }
+
+  let html = ''
+  let lastIndex = 0
+  let escape: string
+
+  for (let index = match.index, len = value.length; index < len; index++) {
+    /* oxlint-disable eslint/no-magic-numbers */
+    switch (value.charCodeAt(index)) {
+      case 34: // "
+        escape = '&quot;'
+        break
+      case 38: // &
+        escape = '&amp;'
+        break
+      case 60: // <
+        escape = '&lt;'
+        break
+      case 62: // >
+        escape = '&gt;'
+        break
+      default:
+        continue
+    }
+    /* oxlint-enable eslint/no-magic-numbers */
+
+    if (lastIndex !== index) {
+      html += value.substring(lastIndex, index)
+    }
+
+    lastIndex = index + 1
+    html += escape
+  }
+
+  return lastIndex !== value.length
+    ? html + value.substring(lastIndex)
+    : html
+}
+
 export function headDescriptorToHtml(descriptor: HeadDescriptor): string {
   const { tag } = descriptor
   let html = ''
@@ -32,7 +84,7 @@ export function headDescriptorToHtml(descriptor: HeadDescriptor): string {
         if (key === 'code') {
           code = String(resolvedValue)
         } else {
-          html += ` ${key.toLowerCase()}="${String(resolvedValue).replace(/"/g, '\\"')}"`
+          html += ` ${key.toLowerCase()}="${escapeHtml(String(resolvedValue))}"`
         }
       }
     })

--- a/packages/svelte-ssr/src/renderer/index.spec.ts
+++ b/packages/svelte-ssr/src/renderer/index.spec.ts
@@ -3,6 +3,16 @@ import {
   it,
   expect
 } from 'vitest'
+import {
+  InjectionContext,
+  provide
+} from '@nano_kit/store'
+import {
+  Page$,
+  lang,
+  title
+} from '@nano_kit/router'
+import type { RenderData } from '@nano_kit/svelte-ssr/renderer'
 import { renderer } from '../../test/app/renderer.js'
 
 renderer.manifest = {
@@ -51,6 +61,25 @@ describe('svelte-ssr', () => {
       expect((await renderer.render('/')).html).toBe('<!doctype html><html><head><title>Home Page</title><meta charset="utf-8" /><script type="module" src="/assets/client-Dfg_FsOr.js" /></script></head><body><div id="app"><!--[--><!--[0--><!--[--><main><!--[0--><!--[--><div>Home John Doe</div><!--]--><!--]--><!----></main><!--]--><!--]--><!--]--></div><script>window.__DEHYDRATED__=[["data",{"user":"John Doe"}]]</script></body></html>')
 
       expect((await renderer.render('/about')).html).toBe('<!doctype html><html><head><title>About Page</title><meta charset="utf-8" /><script type="module" src="/assets/client-Dfg_FsOr.js" /></script></head><body><div id="app"><!--[--><!--[0--><!--[--><main><!--[0--><!--[--><div>About Miguel loves cheese</div><!--]--><!--]--><!----></main><!--]--><!--]--><!--]--></div><script>window.__DEHYDRATED__=[["data",{"info":"Miguel loves cheese"}]]</script></body></html>')
+    })
+
+    it('should escape the title and html attributes', async () => {
+      const data = {
+        context: new InjectionContext([provide(Page$, () => null)]),
+        head: [
+          lang('en" onload="x'),
+          title('Tom & "Jerry" <3')
+        ],
+        dehydrated: [],
+        statusCode: 200,
+        redirect: null,
+        page: null,
+        setCookieHeaders: null
+      } as RenderData
+      const html = await renderer.renderToString(data)
+
+      expect(html).toContain('<html lang="en&quot; onload=&quot;x">')
+      expect(html).toContain('<title>Tom &amp; &quot;Jerry&quot; &lt;3</title>')
     })
   })
 })

--- a/packages/svelte-ssr/src/renderer/index.ts
+++ b/packages/svelte-ssr/src/renderer/index.ts
@@ -14,6 +14,7 @@ import {
   type RenderData,
   ROOT_ID,
   Renderer,
+  escapeHtml,
   headDescriptorToHtml
 } from '@nano_kit/ssr/renderer'
 
@@ -53,7 +54,7 @@ export class SvelteRenderer extends Renderer {
     })
 
     if (title) {
-      head = `<title>${title}</title>${head}`
+      head = `<title>${escapeHtml(title)}</title>${head}`
     }
 
     const result = await render(((
@@ -65,6 +66,6 @@ export class SvelteRenderer extends Renderer {
       return App(internals, props)
     }) as Component)
 
-    return `<html${lang ? ` lang="${lang}"` : ''}${dir ? ` dir="${dir}"` : ''}><head>${head}${result.head}</head><body><div id="${ROOT_ID}">${result.body}</div><script>${this.dehydratedScript(data.dehydrated)}</script></body></html>`
+    return `<html${lang ? ` lang="${escapeHtml(lang)}"` : ''}${dir ? ` dir="${escapeHtml(dir)}"` : ''}><head>${head}${result.head}</head><body><div id="${ROOT_ID}">${result.body}</div><script>${this.dehydratedScript(data.dehydrated)}</script></body></html>`
   }
 }


### PR DESCRIPTION
## Why

The SSR renderers built the document from raw strings: `<title>` (and `lang` / `dir` in the Svelte renderer) were interpolated as is, `headDescriptorToHtml` escaped attribute quotes with a backslash instead of an entity, and `dehydratedScript` inlined the `JSON.stringify` output, so a dehydrated value containing `</script>` closed the tag and the rest of the value was parsed as markup.

## What

- `@nano_kit/ssr/renderer`: new `escapeHtml` (`&`, `<`, `>`, `"`) that returns strings without special characters as is and otherwise scans with `charCodeAt`; `headDescriptorToHtml` uses it for attribute values; `dehydratedScript` escapes `<` as `\u003c`.
- React and Preact renderers escape the title; the Svelte renderer escapes the title, `lang` and `dir` (there the whole document is a template string).
- Tests: `escapeHtml`, attribute values (static, reactive, empty), raw `script` code, the `</script>` case for `dehydratedScript`, and title escaping in all three adapters (plus `lang` for Svelte).

`oxlint`, `vitest` and `tsc --noEmit` pass in `ssr`, `react-ssr`, `preact-ssr` and `svelte-ssr`.
