### PR TITLE
fix(svelte-router): resolve `getLocation`, `getNavigation`, `getPaths` and `getCanGoBack` through the Svelte context

### DIFF
--- a/packages/svelte-router/src/hooks.spec.ts
+++ b/packages/svelte-router/src/hooks.spec.ts
@@ -1,0 +1,93 @@
+import {
+  afterEach,
+  describe,
+  expect,
+  it
+} from 'vitest'
+import {
+  cleanup,
+  fireEvent,
+  render
+} from '@testing-library/svelte'
+import { tick } from 'svelte'
+import { provide } from '@nano_kit/store'
+import {
+  type Routes,
+  LocationNavigation$,
+  virtualNavigation
+} from '@nano_kit/router'
+import HooksFixture from '../test/HooksFixture.svelte'
+
+const routes = {
+  home: '/',
+  about: '/about'
+} as const
+
+function renderFixture(path: string) {
+  const locationNavigation = virtualNavigation<Routes>(path, routes)
+  const rendered = render(HooksFixture, {
+    props: {
+      context: [
+        provide(LocationNavigation$, locationNavigation)
+      ]
+    }
+  })
+
+  return {
+    ...rendered,
+    navigation: locationNavigation[1]
+  }
+}
+
+afterEach(cleanup)
+
+describe('svelte-router', () => {
+  describe('hooks', () => {
+    describe('getLocation', () => {
+      it('should return the location signal from the injection context', async () => {
+        const { getByTestId, navigation } = renderFixture('/')
+
+        expect(getByTestId('pathname').textContent).toBe('/')
+        expect(getByTestId('route').textContent).toBe('home')
+
+        navigation.push('/about')
+        await tick()
+
+        expect(getByTestId('pathname').textContent).toBe('/about')
+        expect(getByTestId('route').textContent).toBe('about')
+      })
+    })
+
+    describe('getNavigation', () => {
+      it('should return the navigation from the injection context', async () => {
+        const { getByTestId, getByText } = renderFixture('/')
+
+        await fireEvent.click(getByText('Go'))
+        await tick()
+
+        expect(getByTestId('pathname').textContent).toBe('/about')
+      })
+    })
+
+    describe('getPaths', () => {
+      it('should return the path builders from the injection context', () => {
+        const { getByTestId } = renderFixture('/')
+
+        expect(getByTestId('about').textContent).toBe('/about')
+      })
+    })
+
+    describe('getCanGoBack', () => {
+      it('should return the can go back signal from the injection context', async () => {
+        const { getByTestId, navigation } = renderFixture('/')
+
+        expect(getByTestId('can-go-back').textContent).toBe('false')
+
+        navigation.push('/about')
+        await tick()
+
+        expect(getByTestId('can-go-back').textContent).toBe('true')
+      })
+    })
+  })
+})

--- a/packages/svelte-router/src/hooks.ts
+++ b/packages/svelte-router/src/hooks.ts
@@ -1,7 +1,5 @@
-import {
-  inject,
-  toSignal
-} from '@nano_kit/store'
+import { toSignal } from '@nano_kit/store'
+import { getInject } from '@nano_kit/svelte'
 import {
   CanGoBack$,
   Location$,
@@ -14,7 +12,7 @@ import {
  * @returns Current route location signal.
  */
 export function getLocation() {
-  return inject(Location$)
+  return getInject(Location$)
 }
 
 /**
@@ -22,7 +20,7 @@ export function getLocation() {
  * @returns Navigation API.
  */
 export function getNavigation() {
-  return inject(Navigation$)
+  return getInject(Navigation$)
 }
 
 /**
@@ -30,7 +28,7 @@ export function getNavigation() {
  * @returns Object with path generators for each route.
  */
 export function getPaths() {
-  return inject(Paths$)
+  return getInject(Paths$)
 }
 
 /**
@@ -38,5 +36,5 @@ export function getPaths() {
  * @returns Signal that returns true if back navigation is possible, false otherwise.
  */
 export function getCanGoBack() {
-  return toSignal(inject(CanGoBack$))
+  return toSignal(getInject(CanGoBack$))
 }

--- a/packages/svelte-router/test/HooksFixture.svelte
+++ b/packages/svelte-router/test/HooksFixture.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import type { InjectionProvider } from '@nano_kit/store'
+  import { setInjectionContext } from '@nano_kit/svelte'
+  import {
+    getCanGoBack,
+    getLocation,
+    getNavigation,
+    getPaths
+  } from '../src/hooks.js'
+
+  interface Props {
+    context: InjectionProvider[]
+  }
+
+  const props: Props = $props()
+
+  // svelte-ignore state_referenced_locally
+  setInjectionContext(props.context)
+
+  const location = getLocation()
+  const navigation = getNavigation()
+  const paths = getPaths()
+  const canGoBack = getCanGoBack()
+</script>
+
+<div data-testid="pathname">{$location.pathname}</div>
+<div data-testid="route">{$location.route}</div>
+<div data-testid="about">{paths.about}</div>
+<div data-testid="can-go-back">{String($canGoBack)}</div>
+<button onclick={() => navigation.push(paths.about)}>Go</button>


### PR DESCRIPTION
## Why

`getLocation`, `getNavigation`, `getPaths` and `getCanGoBack` from `@nano_kit/svelte-router` called the core `inject`, which reads the injection context of a running store factory. In component code, even below `setInjectionContext`, they threw `Cannot inject dependency outside of injection context`; the examples worked around it with `getInject(Navigation$)` from `@nano_kit/svelte`.

## What

- The four helpers use `getInject` from `@nano_kit/svelte`, like `getPage`, `listenLinks` and `Link`. Inside store factories they keep working, because `getInject` passes `undefined` there and `inject` falls back to the current context.
- `hooks.spec.ts` with a `HooksFixture.svelte` component: one test per helper (location, navigation through `push` and a click, path builders, can go back). The tests failed with the error above before the change.

`oxlint`, `vitest` (svelte-router and svelte-kit, which re-exports the helpers) and `svelte-check` pass.
