### PR TITLE
fix(svelte-router): re-render `App` when the matched page component changes

### DIFF
--- a/packages/svelte-router/src/App.spec.ts
+++ b/packages/svelte-router/src/App.spec.ts
@@ -1,0 +1,86 @@
+import {
+  afterEach,
+  describe,
+  expect,
+  it
+} from 'vitest'
+import {
+  cleanup,
+  render
+} from '@testing-library/svelte'
+import { tick } from 'svelte'
+import { provide } from '@nano_kit/store'
+import {
+  type Routes,
+  LocationNavigation$,
+  Page$,
+  page,
+  virtualNavigation
+} from '@nano_kit/router'
+import { router } from './core.js'
+import AppFixture from '../test/AppFixture.svelte'
+import HomePage from '../test/pages/HomePage.svelte'
+import AboutPage from '../test/pages/AboutPage.svelte'
+
+const routes = {
+  home: '/home',
+  about: '/about'
+} as const
+
+function getHtml(container: HTMLElement) {
+  return container.innerHTML.replaceAll('<!---->', '')
+}
+
+afterEach(cleanup)
+
+describe('svelte-router', () => {
+  describe('App', () => {
+    it('should render the page matched from the injection context', () => {
+      const locationNavigation = virtualNavigation<Routes>('/home', routes)
+      const { container } = render(AppFixture, {
+        props: {
+          context: [
+            provide(LocationNavigation$, locationNavigation),
+            provide(Page$, router(locationNavigation[0], [
+              page('home', HomePage),
+              page('about', AboutPage)
+            ]))
+          ]
+        }
+      })
+
+      expect(getHtml(container)).toBe('<div>Home Page</div>')
+    })
+
+    it('should switch the page when the location changes', async () => {
+      const locationNavigation = virtualNavigation<Routes>('/home', routes)
+      const [, navigation] = locationNavigation
+      const { container } = render(AppFixture, {
+        props: {
+          context: [
+            provide(LocationNavigation$, locationNavigation),
+            provide(Page$, router(locationNavigation[0], [
+              page('home', HomePage),
+              page('about', AboutPage)
+            ]))
+          ]
+        }
+      })
+
+      navigation.push('/about')
+      await tick()
+
+      expect(getHtml(container)).toBe('<div>About Page</div>')
+
+      navigation.push('/unknown')
+      await tick()
+
+      expect(getHtml(container)).toBe('')
+
+      navigation.push('/home')
+      await tick()
+
+      expect(getHtml(container)).toBe('<div>Home Page</div>')
+    })
+  })
+})

--- a/packages/svelte-router/src/App.svelte
+++ b/packages/svelte-router/src/App.svelte
@@ -2,7 +2,7 @@
   import { getPage } from './core.js'
 
   const page = getPage()
-  const Page = $page
+  const Page = $derived($page)
 </script>
 
 {#if Page}

--- a/packages/svelte-router/test/AppFixture.svelte
+++ b/packages/svelte-router/test/AppFixture.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import type { InjectionProvider } from '@nano_kit/store'
+  import { setInjectionContext } from '@nano_kit/svelte'
+  import App from '../src/App.svelte'
+
+  interface Props {
+    context: InjectionProvider[]
+  }
+
+  const props: Props = $props()
+
+  // svelte-ignore state_referenced_locally
+  setInjectionContext(props.context)
+</script>
+
+<App />

--- a/packages/svelte-ssr/src/renderer/index.spec.ts
+++ b/packages/svelte-ssr/src/renderer/index.spec.ts
@@ -58,9 +58,9 @@ renderer.manifest = {
 describe('svelte-ssr', () => {
   describe('renderer', () => {
     it('should render html', async () => {
-      expect((await renderer.render('/')).html).toBe('<!doctype html><html><head><title>Home Page</title><meta charset="utf-8" /><script type="module" src="/assets/client-Dfg_FsOr.js" /></script></head><body><div id="app"><!--[--><!--[0--><!--[--><main><!--[0--><!--[--><div>Home John Doe</div><!--]--><!--]--><!----></main><!--]--><!--]--><!--]--></div><script>window.__DEHYDRATED__=[["data",{"user":"John Doe"}]]</script></body></html>')
+      expect((await renderer.render('/')).html).toBe('<!doctype html><html><head><title>Home Page</title><meta charset="utf-8" /><script type="module" src="/assets/client-Dfg_FsOr.js" /></script></head><body><div id="app"><!--[--><!--[0--><!--[--><!--[--><main><!--[0--><!--[--><div>Home John Doe</div><!--]--><!--]--><!----></main><!--]--><!--]--><!--]--><!--]--></div><script>window.__DEHYDRATED__=[["data",{"user":"John Doe"}]]</script></body></html>')
 
-      expect((await renderer.render('/about')).html).toBe('<!doctype html><html><head><title>About Page</title><meta charset="utf-8" /><script type="module" src="/assets/client-Dfg_FsOr.js" /></script></head><body><div id="app"><!--[--><!--[0--><!--[--><main><!--[0--><!--[--><div>About Miguel loves cheese</div><!--]--><!--]--><!----></main><!--]--><!--]--><!--]--></div><script>window.__DEHYDRATED__=[["data",{"info":"Miguel loves cheese"}]]</script></body></html>')
+      expect((await renderer.render('/about')).html).toBe('<!doctype html><html><head><title>About Page</title><meta charset="utf-8" /><script type="module" src="/assets/client-Dfg_FsOr.js" /></script></head><body><div id="app"><!--[--><!--[0--><!--[--><!--[--><main><!--[0--><!--[--><div>About Miguel loves cheese</div><!--]--><!--]--><!----></main><!--]--><!--]--><!--]--><!--]--></div><script>window.__DEHYDRATED__=[["data",{"info":"Miguel loves cheese"}]]</script></body></html>')
     })
 
     it('should escape the title and html attributes', async () => {


### PR DESCRIPTION
## Why

`App` from `@nano_kit/svelte-router` read the page signal once (`const Page = $page` in legacy mode), so when the matched top-level page component changed, the old page stayed on screen. It went unnoticed because pages usually sit under one root `layout()`, whose `Outlet` does the switching. The default client of `@nano_kit/svelte-ssr` renders the same `App`.

## What

- `App.svelte`: `const Page = $derived($page)`, the same shape as `Outlet.svelte`.
- `App.spec.ts` with an `AppFixture.svelte` component: renders the page from `Page$`, switches on `navigation.push`, renders nothing for an unknown route and comes back. The switching test failed before the change.
- `svelte-ssr` renderer spec: the expected HTML gains one pair of hydration markers (`<!--[-->` / `<!--]-->`) because `App` now compiles in runes mode; the markup itself is unchanged.

`oxlint`, `vitest` (svelte-router and svelte-ssr) and `svelte-check` pass.
