### PR TITLE
fix(next-router): let a nested `NextNavigationProvider` pick up search params below a prerenderable layout

### DIFF
--- a/packages/next-router/src/hooks.spec.tsx
+++ b/packages/next-router/src/hooks.spec.tsx
@@ -5,15 +5,26 @@ import {
   vi,
   beforeEach
 } from 'vitest'
+import type { PropsWithChildren } from 'react'
 import {
   renderHook,
   act
 } from '@testing-library/react'
+import { provide } from '@nano_kit/store'
+import { InjectionContextProvider } from '@nano_kit/react'
+import {
+  type Routes,
+  LocationNavigation$,
+  virtualNavigation
+} from '@nano_kit/router'
 import {
   mockNavigation,
   mockNavigationModule
 } from '../test/navigation.mock.js'
-import { useNextNavigation } from './hooks.js'
+import {
+  useNextNavigation,
+  useShouldProvideNextNavigation
+} from './hooks.js'
 
 vi.mock('next/navigation.js', () => mockNavigationModule)
 
@@ -91,6 +102,70 @@ describe('next-router', () => {
         })
 
         expect(mockNavigation.push).toHaveBeenCalledWith('/user/42')
+      })
+    })
+
+    describe('useShouldProvideNextNavigation', () => {
+      beforeEach(() => {
+        mockNavigation.reset()
+      })
+
+      it('should provide navigation when there is no location in the injection context', () => {
+        const { result } = renderHook(() => useShouldProvideNextNavigation())
+
+        expect(result.current).toBe(true)
+      })
+
+      it('should not provide navigation when the location above already has search params', () => {
+        mockNavigation.search = 'page=2'
+
+        const locationNavigation = virtualNavigation<Routes>('/?page=2', routes)
+        const wrapper = ({ children }: PropsWithChildren) => (
+          <InjectionContextProvider context={[provide(LocationNavigation$, locationNavigation)]}>
+            {children}
+          </InjectionContextProvider>
+        )
+        const { result } = renderHook(() => useShouldProvideNextNavigation(), {
+          wrapper
+        })
+
+        expect(result.current).toBe(false)
+      })
+
+      it('should provide navigation when the location above was created without search params and they are available now', () => {
+        mockNavigation.searchParamsAvailable = false
+
+        const { result: outer } = renderHook(() => useNextNavigation(routes))
+
+        mockNavigation.searchParamsAvailable = true
+        mockNavigation.search = 'page=2'
+
+        const wrapper = ({ children }: PropsWithChildren) => (
+          <InjectionContextProvider context={[provide(LocationNavigation$, outer.current as unknown)]}>
+            {children}
+          </InjectionContextProvider>
+        )
+        const { result } = renderHook(() => useShouldProvideNextNavigation(), {
+          wrapper
+        })
+
+        expect(result.current).toBe(true)
+      })
+
+      it('should not provide navigation while search params stay unavailable', () => {
+        mockNavigation.searchParamsAvailable = false
+
+        const { result: outer } = renderHook(() => useNextNavigation(routes))
+        const wrapper = ({ children }: PropsWithChildren) => (
+          <InjectionContextProvider context={[provide(LocationNavigation$, outer.current as unknown)]}>
+            {children}
+          </InjectionContextProvider>
+        )
+        const { result } = renderHook(() => useShouldProvideNextNavigation(), {
+          wrapper
+        })
+
+        expect(result.current).toBe(false)
       })
     })
   })

--- a/packages/next-router/src/hooks.ts
+++ b/packages/next-router/src/hooks.ts
@@ -23,7 +23,7 @@ import {
   type RouteLocation,
   type Navigation,
   type Location,
-  Location$,
+  LocationNavigation$,
   PushHistoryAction,
   ReplaceHistoryAction,
   createCachedMatcher,
@@ -31,7 +31,7 @@ import {
   updateLocation
 } from '@nano_kit/router'
 
-const SEARCH_PARAMS_FALLBACK = '?__searchParamsFallback__=true'
+const SEARCH_PARAMS_FALLBACK = '__searchParamsFallback__=true'
 
 export function useShouldProvideNextNavigation() {
   const context = useInjectionContext()
@@ -43,9 +43,9 @@ export function useShouldProvideNextNavigation() {
     isSearchParamsAvailable = false
   }
 
-  const location = context?.get(Location$, true)
+  const location = context?.get(LocationNavigation$, true)?.[0]
 
-  return !location || location.$search() === SEARCH_PARAMS_FALLBACK && isSearchParamsAvailable
+  return !location || location.$search() === `?${SEARCH_PARAMS_FALLBACK}` && isSearchParamsAvailable
 }
 
 function useRouteLocation<const R extends Routes = Routes>(

--- a/packages/next-router/test/navigation.mock.ts
+++ b/packages/next-router/test/navigation.mock.ts
@@ -10,6 +10,7 @@ export const mockNavigation = {
   forward: vi.fn() as MockInstance,
   pathname: '/',
   search: '',
+  searchParamsAvailable: true,
   reset() {
     this.push.mockReset()
     this.replace.mockReset()
@@ -17,6 +18,7 @@ export const mockNavigation = {
     this.forward.mockReset()
     this.pathname = '/'
     this.search = ''
+    this.searchParamsAvailable = true
   }
 }
 
@@ -28,7 +30,13 @@ export const RedirectType = {
 export const mockNavigationModule = {
   useRouter: () => mockNavigation,
   usePathname: () => mockNavigation.pathname,
-  useSearchParams: () => new URLSearchParams(mockNavigation.search),
+  useSearchParams: () => {
+    if (!mockNavigation.searchParamsAvailable) {
+      throw new Error('Bail out to client-side rendering')
+    }
+
+    return new URLSearchParams(mockNavigation.search)
+  },
   redirect: vi.fn() as MockInstance,
   RedirectType
 }


### PR DESCRIPTION
## Why

Below a `prerenderable` layout the root `NextNavigationProvider` creates its location without search params (Next bails out of `useSearchParams` during the static render), and a page-level provider is supposed to replace it once search params are available. `useShouldProvideNextNavigation` never did that:

- the fallback marker started with `?` and `useRouteLocation` prefixed another one, so `$search()` held `??__searchParamsFallback__=true` and the equality check always failed;
- the lookup used `context.get(Location$, true)`, but the provider registers `LocationNavigation$`; `Location$` is only present once something above has injected it (the example's `Header` did, which is why it seemed to work), otherwise a nested provider always created a second navigation.

## What

- `hooks.ts`: the marker has no `?`, the check compares `$search()` with `` `?${SEARCH_PARAMS_FALLBACK}` `` and reads the location from `LocationNavigation$`.
- `hooks.spec.tsx`: `useShouldProvideNextNavigation` cases for no navigation above, a navigation with search params above, a fallback navigation above with params available now, and params still unavailable. The last three failed before the change.
- `navigation.mock.ts`: `searchParamsAvailable` flag, `useSearchParams` throws when it is `false`, like Next during a static prerender.

`oxlint`, `vitest` and `tsc --noEmit` pass in `next-router`.
