### PR TITLE
fix(platform-web): accept `null` in `parseLocales` for a missing `Accept-Language` header

### DIFF
--- a/packages/platform-web/oxlint.config.ts
+++ b/packages/platform-web/oxlint.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     'typescript/unified-signatures': 'off',
     'eslint/no-sequences': 'off',
     'eslint/no-return-assign': 'off',
-    'eslint/no-multi-assign': 'off'
+    'eslint/no-multi-assign': 'off',
+    'eslint/no-param-reassign': 'off'
   }
 })

--- a/packages/platform-web/src/locale.spec.ts
+++ b/packages/platform-web/src/locale.spec.ts
@@ -53,6 +53,13 @@ describe('platform-web', () => {
         })
       })
 
+      it('should fallback to english when header is null', () => {
+        expect(parseLocales(null)).toEqual({
+          language: 'en',
+          languages: ['en']
+        })
+      })
+
       it('should create a container compatible with browserLocale', () => {
         expect(browserLocale(
           parseLocales('en;q=0.5,ru;q=1'),

--- a/packages/platform-web/src/locale.ts
+++ b/packages/platform-web/src/locale.ts
@@ -65,11 +65,11 @@ export function browserLocale(
 
 /**
  * Creates a browser-like locale container from an `Accept-Language` header value.
- * @param acceptLanguage - Raw `Accept-Language` request header value.
+ * @param acceptLanguage - Raw `Accept-Language` request header value, or `null` when the header is missing.
  * @returns Locale container ordered by header quality and declaration order.
  */
 /* @__NO_SIDE_EFFECTS__ */
-export function parseLocales(acceptLanguage = ''): LocalesContainer {
+export function parseLocales(acceptLanguage?: string | null): LocalesContainer {
   const entries: {
     index: number
     language: string
@@ -109,6 +109,8 @@ export function parseLocales(acceptLanguage = ''): LocalesContainer {
     value = ''
     mode = 0
   }
+
+  acceptLanguage ||= ''
 
   for (let i = 0, len = acceptLanguage.length; i < len; i++) {
     const char = acceptLanguage[i]


### PR DESCRIPTION
## Why

`Headers.get('accept-language')` returns `null` when the request has no `Accept-Language` header. `parseLocales(acceptLanguage = '')` only defaulted `undefined` and then read `acceptLanguage.length`, so the example from the docs, `parseLocales(request.headers.get('accept-language'))`, threw `TypeError: Cannot read properties of null (reading 'length')` on the first request without the header (curl, bots, health checks). Under `strict` TypeScript the example did not even type-check, since `string | null` is not assignable to `string | undefined`.

The built-in SSR renderer was not affected: it passes `headers?.acceptLanguage`, which is typed `string | undefined`.

## What

- `parseLocales` now takes `acceptLanguage?: string | null` and normalizes it with `acceptLanguage ||= ''`, so `null` behaves like `undefined` and `''`: `{ language: 'en', languages: ['en'] }`.
- `eslint/no-param-reassign` is turned off for the package in `oxlint.config.ts`, the same way `agera` does it. A local `const` would have cost 4 B of gzip and pushed the package over its 3.4 kB size limit; the reassignment keeps it at 3399 B.
- New test: `should fallback to english when header is null`.

## Checks

- `oxlint`, `tsc --noEmit`, `vitest run` (58 tests) in `packages/platform-web` pass.
- `size-limit`: 3399 B gzip (limit 3400 B), 3027 B brotli (limit 3.05 kB).
