### PR TITLE
fix(intl): require explicit options next to a fallback in the Intl formatters

### DIFF
--- a/packages/intl/src/format/datetime.ts
+++ b/packages/intl/src/format/datetime.ts
@@ -43,12 +43,12 @@ export function datetime(
 /**
  * Creates a locale-aware date/time formatter with a fallback value.
  * @param fallback - Value used when the input is `undefined` or `null`.
- * @param options - `Intl.DateTimeFormat` options.
+ * @param options - `Intl.DateTimeFormat` options, or `{}` for the defaults.
  * @returns Formatter that returns a formatted string or `undefined`.
  */
 export function datetime(
   fallback: Date | number | string,
-  options?: Intl.DateTimeFormatOptions
+  options: Intl.DateTimeFormatOptions
 ): Format<Date | number | string | undefined, string | undefined>
 
 /**
@@ -59,9 +59,9 @@ export function datetime(
  * @returns Formatter that returns a formatted string or `undefined`.
  */
 export function datetime<I = Date | number | string>(
-  optionsOrFallback?: Intl.DateTimeFormatOptions | false | I,
-  maybeOptions?: Intl.DateTimeFormatOptions | false,
-  format?: IntlFormatFn<Intl.DateTimeFormat, I, Intl.DateTimeFormatOptions>
+  optionsOrFallback: Intl.DateTimeFormatOptions | false | I | undefined,
+  maybeOptions: Intl.DateTimeFormatOptions | false | undefined,
+  format: IntlFormatFn<Intl.DateTimeFormat, I, Intl.DateTimeFormatOptions>
 ): Format<I | undefined, string | undefined>
 
 /* @__NO_SIDE_EFFECTS__ */

--- a/packages/intl/src/format/duration.ts
+++ b/packages/intl/src/format/duration.ts
@@ -38,12 +38,12 @@ export function duration(
 /**
  * Creates a locale-aware duration formatter with a fallback value.
  * @param fallback - Value used when the input is `undefined` or `null`.
- * @param options - `Intl.DurationFormat` options.
+ * @param options - `Intl.DurationFormat` options, or `{}` for the defaults.
  * @returns Formatter that returns a formatted string or `undefined`.
  */
 export function duration(
   fallback: Duration,
-  options?: Intl.DurationFormatOptions
+  options: Intl.DurationFormatOptions
 ): Format<Duration | undefined, string | undefined>
 
 /* @__NO_SIDE_EFFECTS__ */

--- a/packages/intl/src/format/list.ts
+++ b/packages/intl/src/format/list.ts
@@ -36,12 +36,12 @@ export function list(
 /**
  * Creates a locale-aware list formatter with a fallback value.
  * @param fallback - Value used when the input is `undefined` or `null`.
- * @param options - `Intl.ListFormat` options.
+ * @param options - `Intl.ListFormat` options, or `{}` for the defaults.
  * @returns Formatter that returns a formatted string or `undefined`.
  */
 export function list(
   fallback: Iterable<string>,
-  options?: Intl.ListFormatOptions
+  options: Intl.ListFormatOptions
 ): Format<Iterable<string> | undefined, string | undefined>
 
 /* @__NO_SIDE_EFFECTS__ */

--- a/packages/intl/src/format/number.ts
+++ b/packages/intl/src/format/number.ts
@@ -37,12 +37,12 @@ export function number(
 /**
  * Creates a locale-aware number formatter with a fallback value.
  * @param fallback - Value used when the input is `undefined` or `null`.
- * @param options - `Intl.NumberFormat` options.
+ * @param options - `Intl.NumberFormat` options, or `{}` for the defaults.
  * @returns Formatter that returns a formatted string or `undefined`.
  */
 export function number(
   fallback: number | bigint | string,
-  options?: Intl.NumberFormatOptions
+  options: Intl.NumberFormatOptions
 ): Format<number | bigint | string | undefined, string | undefined>
 
 /**
@@ -53,9 +53,9 @@ export function number(
  * @returns Formatter that returns a formatted string or `undefined`.
  */
 export function number(
-  optionsOrFallback?: Intl.NumberFormatOptions | false | number | bigint | string,
-  maybeOptions?: Intl.NumberFormatOptions | false,
-  format?: IntlFormatFn<Intl.NumberFormat, number | bigint | string, Intl.NumberFormatOptions>
+  optionsOrFallback: Intl.NumberFormatOptions | false | number | bigint | string | undefined,
+  maybeOptions: Intl.NumberFormatOptions | false | undefined,
+  format: IntlFormatFn<Intl.NumberFormat, number | bigint | string, Intl.NumberFormatOptions>
 ): Format<number | bigint | string | undefined, string | undefined>
 
 /* @__NO_SIDE_EFFECTS__ */

--- a/packages/intl/src/format/range.ts
+++ b/packages/intl/src/format/range.ts
@@ -7,9 +7,9 @@ import type {
 type RangeInput<I> = readonly [from: I, to: I]
 
 type RangeFrom<F extends IntlFormatRange<I>, I, O, R> = (
-  optionsOrFallback?: O | false | I,
-  maybeOptions?: O | false,
-  format?: IntlFormatFn<F, I, O>
+  optionsOrFallback: O | false | I | undefined,
+  maybeOptions: O | false | undefined,
+  format: IntlFormatFn<F, I, O>
 ) => Format<I | undefined, R | undefined>
 
 function rangeFormat(
@@ -58,13 +58,13 @@ export function range<F extends IntlFormatRange<I>, I, O, R>(
  * Creates a locale-aware range formatter with a fallback range.
  * @param format - Formatter factory that supports a custom range formatting function.
  * @param fallback - Range used when the input is `undefined` or `null`.
- * @param options - Formatter options.
+ * @param options - Formatter options, or `{}` for the defaults.
  * @returns Formatter that returns a formatted range string or `undefined`.
  */
 export function range<F extends IntlFormatRange<I>, I, O, R>(
   format: RangeFrom<F, I, O, R>,
   fallback: RangeInput<I>,
-  options?: O
+  options: O
 ): Format<RangeInput<I> | undefined, string | undefined>
 
 /* @__NO_SIDE_EFFECTS__ */

--- a/packages/intl/src/format/relativetime.ts
+++ b/packages/intl/src/format/relativetime.ts
@@ -28,7 +28,7 @@ export function relativetime(
  * @returns Formatter that returns a formatted string or `undefined`.
  */
 export function relativetime(
-  options?: RelativeTimeOptions
+  options: RelativeTimeOptions
 ): Format<number | undefined, string | undefined>
 
 /**
@@ -50,7 +50,7 @@ export function relativetime(
  */
 export function relativetime(
   fallback: number,
-  options?: RelativeTimeOptions
+  options: RelativeTimeOptions
 ): Format<number | undefined, string | undefined>
 
 /* @__NO_SIDE_EFFECTS__ */

--- a/website/src/content/docs/intl/api.mdx
+++ b/website/src/content/docs/intl/api.mdx
@@ -152,6 +152,8 @@ This is useful for dates, numbers, and other UI values that come from app state.
 
 Intl formats can be used inside `params(...)` for translated templates, or wrapped with `format(...)` when the value comes from runtime state, API data, or a database.
 
+A fallback is always passed together with options, for example `number(0, {})` or `datetime(fallback, false)`: a lone argument is always read as options.
+
 ### `number(fallback?, options?)`
 
 Formats numbers with `Intl.NumberFormat`.


### PR DESCRIPTION
## Why

The overloads of `number`, `datetime`, `relativetime`, `duration`, `list` and `range` allowed a lone fallback, `number(42)`, and the API page lists them as `number(fallback?, options?)`. The runtime, however, treats the first argument as a fallback only when a second argument is present, so a lone fallback is passed to the `Intl` constructor as options and silently dropped:

```
number(42)(ctx)                   -> undefined
datetime(new Date(0))(ctx)        -> undefined
list(['red', 'green'])(ctx)       -> undefined
range(number, [1, 5])(ctx)        -> undefined
relativetime(-1)(ctx, 2)          -> RangeError: Invalid unit argument
duration({ hours: 1 })(ctx, {…})  -> RangeError: Value 1 out of range for options property hours
```

A runtime check by shape cannot fix this consistently: `duration` takes a plain object for both the fallback and the options, `list` accepts any iterable, `datetime` accepts a `Date`. A partial rule would cost bytes in the shared formatter and still leave some formatters needing explicit options.

## What

- The fallback overloads of all six formatters require `options` (`{}` for the defaults, or `false` for raw mode). `number(42)` is a type error now, `number(42, {})` and `number(42, false)` behave as before. No runtime code changes.
- The custom `format` overloads of `number` and `datetime` require the function and take the first two parameters as explicitly `undefined`-able, so they no longer swallow such calls. The internal `RangeFrom` type mirrors that shape.
- `relativetime(options?)` becomes `relativetime(options)`: formatting without a `unit` threw a `TypeError` for any input.
- JSDoc of the fallback overloads mentions `{}` for the defaults, and the API page gets one sentence with the rule.

## Checks

- `oxlint`, `tsc --noEmit`, `vitest run` (117 tests) in `packages/intl` pass.
