### PR TITLE
feat(intl): use a plain string translation for every plural form and match case

### DIFF
--- a/packages/intl/.size-limit.json
+++ b/packages/intl/.size-limit.json
@@ -4,7 +4,7 @@
     "gzip": true,
     "path": "dist/index.production.js",
     "import": "*",
-    "limit": "2 kB"
+    "limit": "2.05 kB"
   },
   {
     "name": "All publics (Brotli)",
@@ -30,7 +30,7 @@
     "gzip": true,
     "path": "dist/index.production.js",
     "import": "{ intl, text, number, datetime, params, plural, match, cases }",
-    "limit": "1 kB"
+    "limit": "1.05 kB"
   },
   {
     "name": "Basic set (Brotli)",

--- a/packages/intl/src/format/match.spec.ts
+++ b/packages/intl/src/format/match.spec.ts
@@ -218,6 +218,35 @@ describe('intl', () => {
           count: 3
         })).toBe('She has 3 tasks')
       })
+
+      it('should use a string translation for every case', () => {
+        const format = match('gender')
+
+        expect(format(ctx, 'Invited {gender}.')({
+          gender: 'female'
+        })).toBe('Invited female.')
+
+        expect(format(ctx, 'Invited {gender}.')('male')).toBe('Invited male.')
+      })
+
+      it('should use a string translation for every case with cases resolver', () => {
+        const format = match('status', cases({
+          active: text('Active {status}'),
+          disabled: text('Disabled {status}')
+        }))
+
+        expect(format(ctx, 'Status {status}')({
+          status: 'active'
+        })).toBe('Status active')
+      })
+
+      it('should use a string translation for every case with default key resolver', () => {
+        const format = match('role', other('user'))
+
+        expect(format(ctx, 'Area of {role}')({
+          role: 'guest'
+        })).toBe('Area of guest')
+      })
     })
   })
 })

--- a/packages/intl/src/format/match.ts
+++ b/packages/intl/src/format/match.ts
@@ -94,7 +94,7 @@ export function match<
   param: K,
   getKey?: GetKey
 ): Format<
-  FormatsInput<B>,
+  FormatsInput<B> | string,
   MatchFn<K, B>
 >
 
@@ -113,7 +113,7 @@ export function match<
   cases?: CasesFn<K, B>,
   getKey?: GetKey
 ): Format<
-  FormatsInput<B>,
+  FormatsInput<B> | string,
   MatchFn<K, B>
 >
 
@@ -135,7 +135,7 @@ export function match<
   },
   maybeGetKey?: GetKey
 ): Format<
-  FormatsInput<B>,
+  FormatsInput<B> | string,
   MatchFn<K, B>
 > {
   const valuePattern = new RegExp(`{${param}}`, 'g')
@@ -149,11 +149,13 @@ export function match<
     getKey = maybeGetKey ?? casesOrGetKey ?? identity
   }
 
-  return (ctx, input: FormatsInput<B> | undefined) => {
+  return (ctx, input: FormatsInput<B> | string | undefined) => {
     const locale = ctx.$locale()
-    let resolvedCases: Record<string, string | undefined | MatchFn<K, B>> = input ?? {}
+    const isString = typeof input === 'string'
+    // A string never reaches the lookups below, so it is stored as is.
+    let resolvedCases = (input ?? {}) as Record<string, string | undefined | MatchFn<K, B>>
 
-    if (cases) {
+    if (cases && !isString) {
       resolvedCases = {
         ...resolvedCases
       }
@@ -163,8 +165,7 @@ export function match<
 
     return (params) => {
       const value = $get(typeof params === 'object' ? params[param] : params)
-      const key = getKey(value, locale, resolvedCases)
-      const resolvedCase = resolvedCases[key]
+      const resolvedCase = isString ? input : resolvedCases[getKey(value, locale, resolvedCases)]
       const message = isFunction(resolvedCase) ? resolvedCase(params) : resolvedCase
 
       return message?.replace(valuePattern, value as string)

--- a/packages/intl/src/format/plural.spec.ts
+++ b/packages/intl/src/format/plural.spec.ts
@@ -203,6 +203,27 @@ describe('intl', () => {
           count: 3
         })).toBe('She has 3 tasks')
       })
+
+      it('should use a string translation for every form', () => {
+        const format = plural('count')
+
+        expect(format(ctx, '{count} going')({
+          count: 1
+        })).toBe('1 going')
+
+        expect(format(ctx, '{count} going')(3)).toBe('3 going')
+      })
+
+      it('should use a string translation for every form with forms resolver', () => {
+        const format = plural('count', forms({
+          one: text(),
+          other: text()
+        }))
+
+        expect(format(ctx, '{count} going')({
+          count: 1
+        })).toBe('1 going')
+      })
     })
   })
 })

--- a/packages/intl/src/format/plural.ts
+++ b/packages/intl/src/format/plural.ts
@@ -31,7 +31,7 @@ export function plural<
   param: K,
   forms?: CasesFn<K, B>
 ): Format<
-  FormatsInput<B>,
+  FormatsInput<B> | string,
   MatchFn<K, B>
 >
 
@@ -50,7 +50,7 @@ export function plural<
   options: Intl.PluralRulesOptions,
   forms?: CasesFn<K, B>
 ): Format<
-  FormatsInput<B>,
+  FormatsInput<B> | string,
   MatchFn<K, B>
 >
 
@@ -63,7 +63,7 @@ export function plural<
   optionsOrForms?: Intl.PluralRulesOptions | CasesFn<K, B>,
   maybeForms?: CasesFn<K, B>
 ): Format<
-  FormatsInput<B>,
+  FormatsInput<B> | string,
   MatchFn<K, B>
 > {
   let options: Intl.PluralRulesOptions | undefined

--- a/website/src/content/docs/intl/api.mdx
+++ b/website/src/content/docs/intl/api.mdx
@@ -254,7 +254,7 @@ $t().formatAmount([1, 5])
 
 ### `plural(param, forms?)`
 
-Matches an LDML plural form with `Intl.PluralRules`. If `forms(...)` is omitted, `plural` reads forms directly from the translation input.
+Matches an LDML plural form with `Intl.PluralRules`. If `forms(...)` is omitted, `plural` reads forms directly from the translation input. A plain string translation serves every form, which suits locales without plural distinctions.
 
 ```ts
 const [$t] = messages('home', {
@@ -306,7 +306,7 @@ $t().guests({
 
 ### `match(param, cases?)`
 
-Matches a case by parameter value. If `cases(...)` is omitted, `match` reads cases directly from the translation input.
+Matches a case by parameter value. If `cases(...)` is omitted, `match` reads cases directly from the translation input. A plain string translation serves every case.
 
 ```ts
 const [$t] = messages('invite', {


### PR DESCRIPTION
## Why

Translation data is `Record<string, any>` at runtime, so a locale file can hold a plain string where the scheme uses `plural` or `match`, for example a Japanese translation `attendees: '{count}人参加'` next to an English `{ one, other }` object. That string reached the key resolvers untouched:

```
plural('count')(ctx, '{count} going')({ count: 3 })             -> TypeError: Cannot use 'in' operator to search for '3' in {count} going
plural('count', forms({ one, other }))(ctx, '{count} going')(3) -> "u"        (the string was spread into characters)
match('kind', other('b'))(ctx, 'str')({ kind: 'a' })            -> TypeError
```

## What

- `match` short-circuits a string translation: it becomes the message for every case and every `plural` form, `{param}` placeholders included, and the `cases(...)` / `forms(...)` resolvers and key resolvers are skipped for it.
- The input types of `match` and `plural` accept `string`, so typed translation data with a string on such a key passes type-checking.
- The API page mentions the rule in the `plural` and `match` sections.
- Tests: three for `match` (bare, with `cases`, with `other`), two for `plural` (bare, with `forms`).

Wrapping the string as `{ other: input }` was considered and rejected: a `forms({ one, other })` resolver declares `one` with an `undefined` value, so `count: 1` would still resolve to `undefined`, and `match` without `other('other')` never looks at the `other` key.

## Size

The extra branch costs bytes in `match`, which is part of the `All publics` and `Basic set` bundles. Limits are re-pinned on the 0.05 kB step:

| bundle | before | after | limit |
|---|---|---|---|
| All publics (Gzip) | 1993 B | 2009 B | 2 kB → 2.05 kB |
| All publics (Brotli) | 1819 B | 1831 B | 1.85 kB |
| Basic set (Gzip) | 998 B | 1013 B | 1 kB → 1.05 kB |
| Basic set (Brotli) | 888 B | 899 B | 900 B |

## Checks

- `oxlint`, `tsc --noEmit`, `vitest run` (122 tests) and `size-limit` in `packages/intl` pass.
