### PR TITLE
fix(platform-web): broadcast `broadcasted` writes and resets while the signal is not observed

### DIFF
--- a/packages/platform-web/.size-limit.json
+++ b/packages/platform-web/.size-limit.json
@@ -4,7 +4,7 @@
     "gzip": true,
     "path": "dist/index.js",
     "import": "*",
-    "limit": "3.4 kB"
+    "limit": "3.45 kB"
   },
   {
     "name": "All publics (Brotli)",

--- a/packages/platform-web/src/broadcast.spec.ts
+++ b/packages/platform-web/src/broadcast.spec.ts
@@ -52,6 +52,46 @@ describe('platform-web', () => {
       offTarget()
     })
 
+    it('should post messages while the signal is not observed', async () => {
+      const name = channelName()
+      const $source = broadcasted<string>(name)
+      const $target = broadcasted(name, 'idle')
+      const offTarget = effect(() => {
+        $target()
+      })
+
+      $source('ready')
+
+      await waitFor(() => {
+        expect($target()).toBe('ready')
+      })
+
+      offTarget()
+    })
+
+    it('should broadcast a reset', async () => {
+      const name = channelName()
+      const $source = broadcasted<string>(name)
+      const $target = broadcasted(name, 'idle')
+      const offTarget = effect(() => {
+        $target()
+      })
+
+      $source('ready')
+
+      await waitFor(() => {
+        expect($target()).toBe('ready')
+      })
+
+      $source(undefined)
+
+      await waitFor(() => {
+        expect($target()).toBe('idle')
+      })
+
+      offTarget()
+    })
+
     it('should support codecs', async () => {
       const name = channelName()
       const $source = broadcasted(name, [] as number[], JsonCodec)

--- a/packages/platform-web/src/broadcast.ts
+++ b/packages/platform-web/src/broadcast.ts
@@ -10,20 +10,26 @@ import {
 class BroadcastChannelStorage<T> implements SyncedStorage<T> {
   #channel: BroadcastChannel | null = null
 
+  #open(key: string) {
+    return this.#channel ??= typeof BroadcastChannel === 'undefined'
+      ? null
+      : new BroadcastChannel(key)
+  }
+
   get() {
     return null
   }
 
-  set(_key: string, value: T) {
-    this.#channel?.postMessage(value)
+  set(key: string, value: T | null) {
+    this.#open(key)?.postMessage(value)
   }
 
   sub(key: string, callback: (value: T | null) => void) {
-    if (typeof BroadcastChannel === 'undefined') {
+    const channel = this.#open(key)
+
+    if (!channel) {
       return noop
     }
-
-    const channel = this.#channel = new BroadcastChannel(key)
 
     channel.onmessage = event => callback(event.data as T)
 
@@ -33,7 +39,9 @@ class BroadcastChannelStorage<T> implements SyncedStorage<T> {
     }
   }
 
-  del() { /* no-op */ }
+  del(key: string) {
+    this.set(key, null)
+  }
 }
 
 /**


### PR DESCRIPTION
## Why

`BroadcastChannelStorage` opened its channel only in `sub`, and `syncedStored` subscribes to the storage when the signal gets its first subscriber. `set` posted through `this.#channel?.postMessage(...)`, so a write from a tab that did not observe the signal itself was silently dropped. `del` was a no-op, so `$signal(undefined)` never reached other tabs either. Probe in the browser runner, tab A writes and tab B listens:

```
no subscriber in writer tab:   target = "idle"     <- 'logout' lost
with subscriber in writer tab: target = "logout"
after $a(undefined):           target = "logout"   <- reset lost
```

The docs example, a logout button calling `$authEvent('logout')`, is exactly the first case: the tab with the button has no reason to observe `$authEvent`. The existing spec masked it by attaching an `effect` to the source signal before writing.

## What

- `#open(key)` creates the channel lazily with `??=` and holds the single `typeof BroadcastChannel` check. `set` and `sub` share it; unsubscribing still closes and clears the channel, and the next write opens a fresh one.
- `del` posts `null`, which the subscription handler already maps to the default value.
- Tests: `should post messages while the signal is not observed` and `should broadcast a reset`.

## Size

The lazy channel and the reset cost bytes in the only bundle of the package. The limit is re-pinned on the 0.05 kB step:

| bundle | before | after | limit |
|---|---|---|---|
| All publics (Gzip) | 3399 B | 3416 B | 3.4 kB → 3.45 kB |
| All publics (Brotli) | 3027 B | 3039 B | 3.05 kB |

## Checks

- `oxlint`, `tsc --noEmit`, `vitest run` (60 tests, browser mode) and `size-limit` in `packages/platform-web` pass.
