### PR TITLE
fix(platform-web): expire a cookie immediately with `maxAge: 0`

### DIFF
--- a/packages/platform-web/src/cookie.spec.ts
+++ b/packages/platform-web/src/cookie.spec.ts
@@ -83,6 +83,41 @@ describe('platform-web', () => {
       })
     })
 
+    it('should apply max age in seconds', async () => {
+      const $language = cookieStored(cookieStore, {
+        name: 'language',
+        maxAge: 60
+      })
+
+      $language('ru')
+
+      await waitFor(async () => {
+        const cookie = await cookieStore.get('language') as {
+          expires?: number | null
+        } | null
+
+        expect(cookie?.expires).toBeGreaterThan(Date.now())
+        expect(cookie?.expires).toBeLessThanOrEqual(Date.now() + 60000)
+      })
+    })
+
+    it('should expire the cookie immediately with zero max age', async () => {
+      await cookieStore.set('language', 'en')
+
+      const $language = cookieStored(cookieStore, {
+        name: 'language',
+        maxAge: 0
+      })
+
+      expect($language()).toBe('en')
+
+      $language('ru')
+
+      await waitFor(async () => {
+        await expect(cookieStore.get('language')).resolves.toBe(null)
+      })
+    })
+
     it('should support codecs', async () => {
       await cookieStore.set('dark', '1')
 

--- a/packages/platform-web/src/cookie.ts
+++ b/packages/platform-web/src/cookie.ts
@@ -54,10 +54,10 @@ class CookieStorage implements Storage<string> {
       ...options,
       name: key,
       value,
-      expires: maxAge
+      expires: maxAge === undefined
+        ? expires
         // oxlint-disable-next-line eslint/no-magic-numbers
-        ? Date.now() + maxAge * 1000
-        : expires
+        : Date.now() + maxAge * 1000
     })
   }
 

--- a/website/src/content/docs/platform/web.mdx
+++ b/website/src/content/docs/platform/web.mdx
@@ -209,6 +209,8 @@ $theme('dark')
 $theme(null) /* Calls cookieStore.delete({ name: 'theme', path: '/' }) */
 ```
 
+`maxAge` is given in seconds and takes precedence over `expires`, so `maxAge: 0` expires the cookie immediately.
+
 Use `cookieStored` when you only need reads and writes. Use `syncedCookieStored` when the cookie store supports change events and you want the signal to react to external cookie changes.
 
 Assigning `null` or `undefined` deletes the underlying cookie through the provided [`CookieStore`](https://developer.mozilla.org/en-US/docs/Web/API/Cookie_Store_API)-compatible object. When `cookieStored` was created from options, deletion reuses the matching `path`, `domain`, and `partitioned` attributes so the browser removes the same cookie scope. If a default value was provided, the signal falls back to it after deletion.


### PR DESCRIPTION
## Why

`CookieStorage.set` turned `maxAge` into `expires` behind a truthiness check:

```ts
expires: maxAge ? Date.now() + maxAge * 1000 : expires
```

`maxAge: 0` means immediate expiration in `Set-Cookie` terms, but here it read as "not set", so the cookie was written with the `expires` option instead, usually as a session cookie. The new spec `should expire the cookie immediately with zero max age` times out on `main` waiting for the cookie to disappear.

## What

- The check is now `maxAge === undefined`, so zero expires the cookie right away. `maxAge` keeps its precedence over `expires`, as in RFC 6265.
- Two browser tests against the real Cookie Store: `maxAge: 60` lands `expires` within a minute from now, `maxAge: 0` deletes the cookie.
- One sentence on the Cookies docs page: `maxAge` is given in seconds and takes precedence over `expires`.

## Size

`All publics` grows by 3 B gzipped for the `undefined` comparison, 3419 B against the 3.45 kB limit re-pinned in #247.

## Checks

- `oxlint`, `tsc --noEmit`, `vitest run` (62 tests, browser mode) and `size-limit` in `packages/platform-web` pass.
