### PR TITLE
fix(preact): reuse the parent context by default in `HydrationProvider`, as React does

### DIFF
--- a/packages/preact/src/hydration.spec.tsx
+++ b/packages/preact/src/hydration.spec.tsx
@@ -8,11 +8,13 @@ import {
   act
 } from '@testing-library/preact'
 import {
+  type InjectionContext,
   signal,
   hydratable
 } from '@nano_kit/store'
 import {
   InjectionContextProvider,
+  useInjectionContext,
   useInject,
   useSignal
 } from './core.js'
@@ -34,6 +36,12 @@ function Test() {
       {value ?? 'empty'}
     </div>
   )
+}
+
+function Context({ contexts }: { contexts: (InjectionContext | undefined)[] }) {
+  contexts.push(useInjectionContext())
+
+  return null
 }
 
 describe('preact', () => {
@@ -85,6 +93,40 @@ describe('preact', () => {
         )
 
         expect(container.innerHTML).toBe('<div>empty</div>')
+      })
+
+      it('should reuse the parent hydration context by default', () => {
+        const contexts: (InjectionContext | undefined)[] = []
+
+        render(
+          <InjectionContextProvider>
+            <HydrationProvider>
+              <Context contexts={contexts}/>
+              <HydrationProvider>
+                <Context contexts={contexts}/>
+              </HydrationProvider>
+            </HydrationProvider>
+          </InjectionContextProvider>
+        )
+
+        expect(contexts[1]).toBe(contexts[0])
+      })
+
+      it('should create a child context when reuse is disabled', () => {
+        const contexts: (InjectionContext | undefined)[] = []
+
+        render(
+          <InjectionContextProvider>
+            <HydrationProvider>
+              <Context contexts={contexts}/>
+              <HydrationProvider reuse={false}>
+                <Context contexts={contexts}/>
+              </HydrationProvider>
+            </HydrationProvider>
+          </InjectionContextProvider>
+        )
+
+        expect(contexts[1]).not.toBe(contexts[0])
       })
     })
 

--- a/packages/preact/src/hydration.tsx
+++ b/packages/preact/src/hydration.tsx
@@ -25,6 +25,7 @@ export interface HydrationProviderProps extends InjectionContextProps {
   context?: InjectionProvider[]
   /**
    * Whether to reuse an existing InjectionContext or create a new one.
+   * `true` by default.
    */
   reuse?: boolean
 }
@@ -36,7 +37,7 @@ export interface HydrationProviderProps extends InjectionContextProps {
 export function HydrationProvider({
   dehydrated,
   context = [],
-  reuse,
+  reuse = true,
   children
 }: HydrationProviderProps) {
   const currentContext = useInjectionContext()

--- a/website/src/content/docs/store-integrations/preact.mdx
+++ b/website/src/content/docs/store-integrations/preact.mdx
@@ -169,7 +169,7 @@ function App({ dehydrated }) {
 Props:
 - `dehydrated?` — dehydrated key-value pairs `[string, unknown][]`, or a falsy value to skip hydration
 - `context?` — additional injection providers
-- `reuse?` — reuse an existing `InjectionContext` instead of creating a new one; set to `true` if you want the hydration context to be shared with the rest of your app instead of isolated
+- `reuse?` — reuse an existing `InjectionContext` instead of creating a new one; `true` by default
 
 #### `StaticHydrationProvider`
 


### PR DESCRIPTION
## Why

`HydrationProvider` in `@nano_kit/react` defaults `reuse` to `true` since d833400, where nested hydration boundaries were introduced: a nested provider pushes its `dehydrated` snapshot into the shared hydrator and renders its children in the parent context. The Preact port never got that change and left `reuse` undefined, so the same tree created an isolated child context in Preact. The docs mirrored the split: React said "`true` by default", Preact said "set to `true` if you want the hydration context to be shared".

## What

- `packages/preact/src/hydration.tsx`: `reuse = true`, and the prop JSDoc states the default.
- `preact.mdx`: the `reuse` prop line now matches the React page.
- Tests in `hydration.spec.tsx` compare `useInjectionContext()` inside and outside a nested provider: `should reuse the parent hydration context by default` (fails on `main`) and `should create a child context when reuse is disabled`.

Nothing in the repo nests `HydrationProvider` in Preact without an explicit `reuse`: `preact-ssr` and `preact-router` do not use it, and the Preact examples go through `StaticHydrationProvider`.

## Checks

- `oxlint`, `tsc --noEmit`, `vitest run` (11 tests) and `size-limit` in `packages/preact` pass; the size limits are unchanged (666 B gzip of 700 B, 574 B brotli of 600 B).
