### PR TITLE
docs: keep `dehydrated` serializable on flight requests in the Next pages example

### DIFF
--- a/examples/rick-and-morty/next-pages-nano_kit-ssr/src/pages/characters.tsx
+++ b/examples/rick-and-morty/next-pages-nano_kit-ssr/src/pages/characters.tsx
@@ -13,16 +13,12 @@ import CharactersPage from '@/ui/pages/Characters'
 import { Stores$ } from '@/ui/pages/Characters.stores'
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  let dehydrated
-
-  if (!isFlight(context.req.headers)) {
-    dehydrated = await dehydrate(
-      Stores$,
-      [
-        provide(LocationNavigation$, virtualNavigation(context.resolvedUrl, routes))
-      ]
-    )
-  }
+  const dehydrated = !isFlight(context.req.headers) && await dehydrate(
+    Stores$,
+    [
+      provide(LocationNavigation$, virtualNavigation(context.resolvedUrl, routes))
+    ]
+  )
 
   return {
     props: {


### PR DESCRIPTION
## Why

`src/pages/characters.tsx` in the Next pages example skips dehydration on flight requests:

```ts
let dehydrated

if (!isFlight(context.req.headers)) {
  dehydrated = await dehydrate(...)
}

return { props: { dehydrated } }
```

Next rejects an explicitly `undefined` prop returned from `getServerSideProps` in development (`isSerializableProps`, enabled under the dev server and build-time SSG). Reproduced with `NANO_KIT_DEV=1 next dev --webpack` and a real click on the CHARACTERS link from `/episodes`:

```
GET /_next/data/development/characters.json -> 500
GET /characters                             -> 200   (Next falls back to a full reload)

⨯ Error: Error serializing `.dehydrated` returned from `getServerSideProps` in "/characters".
Reason: `undefined` cannot be serialized as JSON. Please use `null` or omit this value.
```

Production is unaffected, since `JSON.stringify` drops the key, but the example demonstrates exactly the scenario that breaks in `next dev`.

## What

The page is back to the single expression it had before 33b6e0b, which only switched to `let` because the navigation setup took two statements at the time:

```ts
const dehydrated = !isFlight(context.req.headers) && await dehydrate(
  Stores$,
  [
    provide(LocationNavigation$, virtualNavigation(context.resolvedUrl, routes))
  ]
)
```

A flight request now returns `false`, which Next serializes and `HydrationProvider` treats as "skip hydration".

## Checks

- Same click after the change: `_next/data/development/characters.json` answers 200, no document request follows, the console is clean.
- `oxlint` on the file passes. The example's `tsc` reports only pre-existing noise from generated `.next` types and `import.meta.env` in the symlinked package sources.
