### PR TITLE
docs(query,intl): describe `cacheTime` by what the cache does and fix the `datetime()` type example

### DIFF
--- a/website/src/content/docs/intl/core-concepts.mdx
+++ b/website/src/content/docs/intl/core-concepts.mdx
@@ -225,7 +225,7 @@ const [$t] = messages('event', {
 })
 ```
 
-Formats are checked against the translation value type when translation data is typed. For example, `datetime()` expects a `Date | number`, so using it directly for a string translation field is a type error.
+Formats are checked against the translation value type when translation data is typed. For example, `duration()` expects a `Duration` object, so using it directly for a string translation field is a type error, while `datetime()` accepts a `Date`, a timestamp or a date string.
 
 ## Formats
 

--- a/website/src/content/docs/query/core-concepts.mdx
+++ b/website/src/content/docs/query/core-concepts.mdx
@@ -165,7 +165,7 @@ Settings control the behavior of queries and mutations. They can be applied glob
 
 ### `cacheTime`
 
-Specifies how long (in milliseconds) data remains in the cache before being marked as stale.
+Specifies how long (in milliseconds) fetched data stays valid, counted from the moment the request settles. Valid data survives the next fetch and stays visible while it loads. Once the cache time has passed, the data is cleared to `null` the moment the next fetch starts.
 
 Default: `Infinity` (data never expires).
 
@@ -183,7 +183,7 @@ const [$post] = query(PostKey, [$postId], fetchPost, [
 ])
 ```
 
-After the cache time expires, data is marked as stale but remains in cache.
+Expiration by itself does not schedule a fetch. Fetches are triggered by observation, parameter changes and `revalidate()`, and they are throttled by [`dedupeTime`](#dedupetime), so unexpired data is refetched as soon as the dedupe window closes, and expired data only disappears when such a fetch begins.
 
 ### `dedupeTime`
 


### PR DESCRIPTION
## Why

Two statements on the docs site describe behavior the code does not have.

**`cacheTime`** (query core concepts) said data "remains in the cache before being marked as stale" and "is marked as stale but remains in cache" after expiration. `CacheStorage.loading` keeps existing data across the next fetch only while `entry.expires > Date.now()` and clears expired data to `null` when that fetch starts (`should clear data when expired`). `settled` counts both `expires` and `dedupes` from the moment the request settles, and nothing fires a fetch on expiration: fetches come from observation, parameter changes and `revalidate()`, throttled by `dedupeTime`.

**`datetime()` on strings** (intl core concepts) was given as the example of a type error for a string translation field. `datetime` accepts `Date | number | string` and formats strings through `new Date(value)`, so neither the types nor the runtime object.

## What

- `query/core-concepts.mdx`: the two `cacheTime` paragraphs now describe validity counted from settle time, data surviving the next fetch while valid, `null` on the first fetch after expiration, and the fact that expiration does not schedule a fetch.
- `intl/core-concepts.mdx`: the example uses `duration()`, whose input is a `Duration` object, and notes that `datetime()` accepts a `Date`, a timestamp or a date string.

## Checks

The intl claim was type-checked against the real `MessagesScheme<{ eventDate: string }>`: `eventDate: datetime()` passes, `eventDate: duration()` is rejected.
