### PR TITLE
fix(router,ssr): render the `httpEquiv` meta prop as the `http-equiv` attribute

### DIFF
--- a/packages/router/.size-limit.json
+++ b/packages/router/.size-limit.json
@@ -4,7 +4,7 @@
     "gzip": true,
     "path": "dist/index.production.js",
     "import": "*",
-    "limit": "4.15 kB"
+    "limit": "4.2 kB"
   },
   {
     "name": "All publics (Brotli)",

--- a/packages/router/src/head.spec.ts
+++ b/packages/router/src/head.spec.ts
@@ -16,11 +16,23 @@ import {
   dir,
   link,
   meta,
-  script
+  script,
+  toHtmlAttribute
 } from './head.js'
 
 describe('router', () => {
   describe('head', () => {
+    describe('toHtmlAttribute', () => {
+      it('should map httpEquiv to http-equiv', () => {
+        expect(toHtmlAttribute('httpEquiv')).toBe('http-equiv')
+      })
+
+      it('should lowercase other prop names', () => {
+        expect(toHtmlAttribute('crossOrigin')).toBe('crossorigin')
+        expect(toHtmlAttribute('content')).toBe('content')
+      })
+    })
+
     describe('syncHead', () => {
       describe('title', () => {
         beforeEach(() => {
@@ -585,6 +597,36 @@ describe('router', () => {
           })
 
           expect(document.head.innerHTML).toBe('<meta name="keywords" content="foo, bar">')
+
+          stop()
+        })
+
+        it('should render httpEquiv as the http-equiv attribute', () => {
+          const stop = syncHead(() => ({
+            default: null,
+            Head$: () => [meta({
+              httpEquiv: 'refresh',
+              content: '0; url=/next'
+            })]
+          }))
+
+          expect(document.head.innerHTML).toBe('<meta http-equiv="refresh" content="0; url=/next">')
+
+          stop()
+        })
+
+        it('should hydrate existing http-equiv meta tag', () => {
+          document.head.innerHTML = '<meta http-equiv="refresh" content="0; url=/next">'
+
+          const stop = syncHead(() => ({
+            default: null,
+            Head$: () => [meta({
+              httpEquiv: 'refresh',
+              content: '0; url=/next'
+            })]
+          }))
+
+          expect(document.head.innerHTML).toBe('<meta http-equiv="refresh" content="0; url=/next">')
 
           stop()
         })

--- a/packages/router/src/head.ts
+++ b/packages/router/src/head.ts
@@ -113,6 +113,16 @@ export function dir($value: DirValue): DirPropertyDescriptor {
   }
 }
 
+/**
+ * Converts a head descriptor prop name to its HTML attribute name.
+ * @param prop - Prop name, such as `httpEquiv` or `crossOrigin`.
+ * @returns The attribute name, such as `http-equiv` or `crossorigin`.
+ */
+/* @__NO_SIDE_EFFECTS__ */
+export function toHtmlAttribute(prop: string) {
+  return prop === 'httpEquiv' ? 'http-equiv' : prop.toLowerCase()
+}
+
 function buildPredicate(tag: string, attributes: [string, AnySignalish][]) {
   let selector = tag
   let count = 0
@@ -126,7 +136,7 @@ function buildPredicate(tag: string, attributes: [string, AnySignalish][]) {
         code = String(resolvedValue)
       } else {
         count++
-        selector += `[${key}="${String(resolvedValue).replace(/"/g, '\\"')}"]`
+        selector += `[${toHtmlAttribute(key)}="${String(resolvedValue).replace(/"/g, '\\"')}"]`
       }
     }
   }
@@ -188,7 +198,7 @@ function startElement(
         if (key === 'code') {
           element.textContent = stringValue
         } else {
-          element.setAttribute(key, stringValue)
+          element.setAttribute(toHtmlAttribute(key), stringValue)
         }
       }
     }

--- a/packages/ssr/src/renderer/utils.spec.ts
+++ b/packages/ssr/src/renderer/utils.spec.ts
@@ -48,6 +48,13 @@ describe('ssr', () => {
           }))).toBe('<meta name="description" />')
         })
 
+        it('should render httpEquiv as the http-equiv attribute', () => {
+          expect(headDescriptorToHtml(meta({
+            httpEquiv: 'refresh',
+            content: '0; url=/next'
+          }))).toBe('<meta http-equiv="refresh" content="0; url=/next" />')
+        })
+
         it('should insert script code as is', () => {
           expect(headDescriptorToHtml(script({
             type: 'application/ld+json',

--- a/packages/ssr/src/renderer/utils.ts
+++ b/packages/ssr/src/renderer/utils.ts
@@ -2,7 +2,8 @@ import {
   type HeadDescriptor,
   type Location,
   type PageRef,
-  PermanentReplaceHistoryAction
+  PermanentReplaceHistoryAction,
+  toHtmlAttribute
 } from '@nano_kit/router'
 import {
   type EmptyValue,
@@ -84,7 +85,7 @@ export function headDescriptorToHtml(descriptor: HeadDescriptor): string {
         if (key === 'code') {
           code = String(resolvedValue)
         } else {
-          html += ` ${key.toLowerCase()}="${escapeHtml(String(resolvedValue))}"`
+          html += ` ${toHtmlAttribute(key)}="${escapeHtml(String(resolvedValue))}"`
         }
       }
     })


### PR DESCRIPTION
## Why

Head descriptor props follow the React naming, and `httpEquiv` is the only prop whose HTML attribute name is not just its lowercase form. `syncHead` passed the prop name straight to `setAttribute` and into the hydration selector, and `headDescriptorToHtml` only lowercased it, so `meta({ httpEquiv: 'refresh', content: '...' })` produced `<meta httpequiv="refresh">` both on the client and in server HTML. Browsers ignore that attribute, and on hydration the selector `meta[httpEquiv="refresh"]` did not match the server tag, so a second `meta` was appended.

## What

- `@nano_kit/router` exports `toHtmlAttribute(prop)`: `httpEquiv` becomes `http-equiv`, everything else is lowercased. `syncHead` uses it for the hydration selector and `setAttribute`.
- `headDescriptorToHtml` in `@nano_kit/ssr` uses the same helper instead of its own `toLowerCase()`.
- Tests: `toHtmlAttribute` unit tests, `should render httpEquiv as the http-equiv attribute` and `should hydrate existing http-equiv meta tag` in the router `meta` suite (both fail on `main`: `httpequiv`, and a duplicated `meta`), and the SSR counterpart in `headDescriptorToHtml`.

## Size

The public helper costs bytes in the router bundle; the limit is re-pinned on the 0.05 kB step:

| bundle | before | after | limit |
|---|---|---|---|
| All publics (Gzip) | 4121 B | 4172 B | 4.15 kB → 4.2 kB |
| All publics (Brotli) | 3703 B | 3748 B | 3.75 kB |
| Minimal set (Gzip) | 1543 B | 1543 B | 1.55 kB |
| Minimal set (Brotli) | 1370 B | 1368 B | 1.4 kB |

## Checks

- `oxlint`, `tsc --noEmit` and `vitest run` pass in `packages/router` (135 tests) and `packages/ssr` (15 tests); `size-limit` passes in `packages/router`.
