### PR TITLE
test: exclude `dist` from vitest runs in every package

### DIFF
--- a/packages/agera/vite.config.js
+++ b/packages/agera/vite.config.js
@@ -23,7 +23,7 @@ export default defineConfig({
     }
   },
   test: {
-    exclude: [...configDefaults.exclude, './package'],
+    exclude: [...configDefaults.exclude, './package', './dist'],
     coverage: {
       reporter: ['lcovonly', 'text'],
       include: ['src/**/*']

--- a/packages/intl/vite.config.js
+++ b/packages/intl/vite.config.js
@@ -24,7 +24,7 @@ export default defineConfig({
     emptyOutDir: false
   },
   test: {
-    exclude: [...configDefaults.exclude, './package'],
+    exclude: [...configDefaults.exclude, './package', './dist'],
     coverage: {
       reporter: ['lcovonly', 'text'],
       include: ['src/**/*']

--- a/packages/kida/vite.config.js
+++ b/packages/kida/vite.config.js
@@ -24,7 +24,7 @@ export default defineConfig({
     emptyOutDir: false
   },
   test: {
-    exclude: [...configDefaults.exclude, './package'],
+    exclude: [...configDefaults.exclude, './package', './dist'],
     coverage: {
       reporter: ['lcovonly', 'text'],
       include: ['src/**/*']

--- a/packages/next-router/vite.config.js
+++ b/packages/next-router/vite.config.js
@@ -45,7 +45,7 @@ export default defineConfig({
   test: {
     environment: 'happy-dom',
     setupFiles: ['@testing-library/jest-dom/vitest'],
-    exclude: [...configDefaults.exclude, './package'],
+    exclude: [...configDefaults.exclude, './package', './dist'],
     coverage: {
       reporter: ['lcovonly', 'text'],
       include: ['src/**/*']

--- a/packages/platform-web/vite.config.js
+++ b/packages/platform-web/vite.config.js
@@ -40,7 +40,7 @@ export default defineConfig({
         }
       ]
     },
-    exclude: [...configDefaults.exclude, './package'],
+    exclude: [...configDefaults.exclude, './package', './dist'],
     coverage: {
       provider: 'v8',
       reporter: ['lcovonly', 'text'],

--- a/packages/preact-router/vite.config.js
+++ b/packages/preact-router/vite.config.js
@@ -25,7 +25,7 @@ export default defineConfig({
   test: {
     environment: 'happy-dom',
     setupFiles: ['@testing-library/jest-dom/vitest'],
-    exclude: [...configDefaults.exclude, './package'],
+    exclude: [...configDefaults.exclude, './package', './dist'],
     coverage: {
       reporter: ['lcovonly', 'text'],
       include: ['src/**/*']

--- a/packages/preact-ssr/vite.config.js
+++ b/packages/preact-ssr/vite.config.js
@@ -12,7 +12,7 @@ export default defineConfig({
     }
   },
   test: {
-    exclude: [...configDefaults.exclude, './package'],
+    exclude: [...configDefaults.exclude, './package', './dist'],
     coverage: {
       reporter: ['lcovonly', 'text'],
       include: ['src/**/*']

--- a/packages/preact/vite.config.js
+++ b/packages/preact/vite.config.js
@@ -25,7 +25,7 @@ export default defineConfig({
   test: {
     environment: 'happy-dom',
     setupFiles: ['@testing-library/jest-dom/vitest'],
-    exclude: [...configDefaults.exclude, './package'],
+    exclude: [...configDefaults.exclude, './package', './dist'],
     coverage: {
       reporter: ['lcovonly', 'text'],
       include: ['src/**/*']

--- a/packages/query/vite.config.js
+++ b/packages/query/vite.config.js
@@ -25,7 +25,7 @@ export default defineConfig({
   },
   test: {
     environment: 'happy-dom',
-    exclude: [...configDefaults.exclude, './package'],
+    exclude: [...configDefaults.exclude, './package', './dist'],
     coverage: {
       reporter: ['lcovonly', 'text'],
       include: ['src/**/*']

--- a/packages/react-router/vite.config.js
+++ b/packages/react-router/vite.config.js
@@ -45,7 +45,7 @@ export default defineConfig({
   test: {
     environment: 'happy-dom',
     setupFiles: ['@testing-library/jest-dom/vitest'],
-    exclude: [...configDefaults.exclude, './package'],
+    exclude: [...configDefaults.exclude, './package', './dist'],
     coverage: {
       reporter: ['lcovonly', 'text'],
       include: ['src/**/*']

--- a/packages/react-ssr/vite.config.js
+++ b/packages/react-ssr/vite.config.js
@@ -12,7 +12,7 @@ export default defineConfig({
     }
   },
   test: {
-    exclude: [...configDefaults.exclude, './package'],
+    exclude: [...configDefaults.exclude, './package', './dist'],
     coverage: {
       reporter: ['lcovonly', 'text'],
       include: ['src/**/*']

--- a/packages/react/vite.config.js
+++ b/packages/react/vite.config.js
@@ -45,7 +45,7 @@ export default defineConfig({
   test: {
     environment: 'happy-dom',
     setupFiles: ['@testing-library/jest-dom/vitest'],
-    exclude: [...configDefaults.exclude, './package'],
+    exclude: [...configDefaults.exclude, './package', './dist'],
     coverage: {
       reporter: ['lcovonly', 'text'],
       include: ['src/**/*']

--- a/packages/router/vite.config.js
+++ b/packages/router/vite.config.js
@@ -35,7 +35,7 @@ export default defineConfig({
       }
     },
     setupFiles: ['@testing-library/jest-dom/vitest'],
-    exclude: [...configDefaults.exclude, './package'],
+    exclude: [...configDefaults.exclude, './package', './dist'],
     coverage: {
       reporter: ['lcovonly', 'text'],
       include: ['src/**/*']

--- a/packages/ssr/vite.config.js
+++ b/packages/ssr/vite.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
     }
   },
   test: {
-    exclude: [...configDefaults.exclude, './package'],
+    exclude: [...configDefaults.exclude, './package', './dist'],
     coverage: {
       reporter: ['lcovonly', 'text'],
       include: ['src/**/*']

--- a/packages/store/vite.config.js
+++ b/packages/store/vite.config.js
@@ -24,7 +24,7 @@ export default defineConfig({
     emptyOutDir: false
   },
   test: {
-    exclude: [...configDefaults.exclude, './package'],
+    exclude: [...configDefaults.exclude, './package', './dist'],
     coverage: {
       reporter: ['lcovonly', 'text'],
       include: ['src/**/*']

--- a/packages/svelte-kit/vite.config.js
+++ b/packages/svelte-kit/vite.config.js
@@ -34,7 +34,7 @@ export default defineConfig({
       '$app/server': new URL('./test/app-server.ts', import.meta.url).pathname
     },
     environment: 'happy-dom',
-    exclude: [...configDefaults.exclude, './package'],
+    exclude: [...configDefaults.exclude, './package', './dist'],
     coverage: {
       reporter: ['lcovonly', 'text'],
       include: ['src/**/*']

--- a/packages/svelte-router/vite.config.js
+++ b/packages/svelte-router/vite.config.js
@@ -28,7 +28,7 @@ export default defineConfig({
   },
   test: {
     environment: 'happy-dom',
-    exclude: [...configDefaults.exclude, './package', './.svelte-kit'],
+    exclude: [...configDefaults.exclude, './package', './dist', './.svelte-kit'],
     coverage: {
       reporter: ['lcovonly', 'text'],
       include: ['src/**/*']

--- a/packages/svelte-ssr/vite.config.js
+++ b/packages/svelte-ssr/vite.config.js
@@ -5,7 +5,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 export default defineConfig({
   plugins: [svelte()],
   test: {
-    exclude: [...configDefaults.exclude, './package'],
+    exclude: [...configDefaults.exclude, './package', './dist'],
     coverage: {
       reporter: ['lcovonly', 'text'],
       include: ['src/**/*']

--- a/packages/svelte/vite.config.js
+++ b/packages/svelte/vite.config.js
@@ -28,7 +28,7 @@ export default defineConfig({
   },
   test: {
     environment: 'happy-dom',
-    exclude: [...configDefaults.exclude, './package'],
+    exclude: [...configDefaults.exclude, './package', './dist'],
     coverage: {
       reporter: ['lcovonly', 'text'],
       include: ['src/**/*']


### PR DESCRIPTION
## Why

Every package config builds its vitest `exclude` as `[...configDefaults.exclude, './package']`. In the installed vitest 5, `configDefaults.exclude` is only `**/node_modules/**` and `**/.git/**`, so `dist` is no longer excluded.

`svelte-router` is where it bites: `svelte-package` compiles everything under `src`, specs included, into `dist`. The `build` script cleans them with `clear:dist-assets`, but `test:dist-types` runs `build:dist` alone, so after `pnpm test:types` a stale `dist/core.spec.js` stays behind and the next `vitest run` executes it against outdated code.

Reproduced with a throwing `dist/stale.spec.js` in `packages/svelte-router`: `vitest run` picked it up and failed; with `./dist` excluded the same file is skipped.

## What

`exclude: [...configDefaults.exclude, './package', './dist']` in all 19 `packages/*/vite.config.js`, in the style of the existing `./package` entry. `svelte-router` keeps its extra `./.svelte-kit`.

## Checks

- `oxlint` on the configs passes.
- `vitest run` spot-checked in `kida`, `react`, `svelte` and `svelte-router` with unchanged counts.
